### PR TITLE
Add note to let the user know that innererror is recursive.

### DIFF
--- a/misc/errors.md
+++ b/misc/errors.md
@@ -29,6 +29,8 @@ property named **error**, which includes all of the details of the error message
 Additional information is included in the body of the failed call. Here is an example
 of a full JSON error body.
 
+**Note**: The **innererror** object is recursive, i.e., it can also have an **innererror** property. 
+
 <!-- { "blockType": "example", "@odata.type": "oneDrive.error" } -->
 ```json
 {


### PR DESCRIPTION
I noticed that **innererror** is actually recursive when I made a request for an item that does not exist. However there was no mention of this in the docs, so this just adds a small note above the example.

For reference, the response body of the request was:

```
{
  "error": {
    "code": "itemNotFound",
    "message": "Item Does Not Exist",
    "innererror": {
      "code": "itemDoesNotExist",
      "innererror": {
        "code": "folderDoesNotExist"
      }
    }
  }
}
```