### PR TITLE
Fix trailing commas and missing json marker

### DIFF
--- a/facets/folder_facet.md
+++ b/facets/folder_facet.md
@@ -8,7 +8,7 @@ It is available on the folder property of [Item][item-resource] resources that r
 <!-- { "blockType": "resource", "@odata.type": "oneDrive.folder" } -->
 ```json
 {
-  "childCount": 0,
+  "childCount": 0
 }
 ```
 ## Properties

--- a/facets/hashes_facet.md
+++ b/facets/hashes_facet.md
@@ -6,7 +6,7 @@ The **Hashes** facet groups different types of hashes into a single structure, f
 A set of hash values for the file.
 
 <!-- { "blockType": "resource", "@odata.type": "oneDrive.hashes" } -->
-```
+```json
 {
 	"crc32Hash": "string (hex)",
 	"sha1Hash": "string (hex)"

--- a/facets/video_facet.md
+++ b/facets/video_facet.md
@@ -12,7 +12,7 @@ represent videos.
   "bitrate": 1234,
   "duration": 1234,
   "height": 720,
-  "width": 480,
+  "width": 480
 }
 ```
 ## Properties

--- a/resources/itemReference.md
+++ b/resources/itemReference.md
@@ -12,7 +12,7 @@ Here is a JSON representation of an itemReference type.
 {
   "driveId": "string (identifier)",
   "id": "string (identifier)",
-  "path": "string (path)",
+  "path": "string (path)"
 }
 ```
 


### PR DESCRIPTION
I am parsing the documentation in order to generate data types for the Go programming language and encountered some simple consistency issues. This pull request adds a json marker to the markdown and removes several trailing commas in JSON payloads.