### PR TITLE
Properly document the update item metadata API

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ a collection of items under the folder.
 | [List an Item's children](items/list.md)         | `GET /drive/items/{id}/children`                       | `GET /drive/root:/{path}:/children`              |
 | [Create an Item](items/create.md)                | `PUT /drive/items/{parent-id}/children/{name}`         | `PUT /drive/root:/{parent-path}/{name}`          |
 | [Upload an Item's contents](items/upload.md)     | `PUT /drive/items/{parent-id}/children/{name}/content` | `PUT /drive/root:/{parent-path}/{name}:/content` |
-| [Update an Item's contents](items/update.md)     | `PATCH /drive/items/{id}`                              | `PATCH /drive/root:/{path}`                      |
+| [Update an Item's metadata](items/update.md)     | `PATCH /drive/items/{id}`                              | `PATCH /drive/root:/{path}`                      |
 | [Delete an Item](items/delete.md)                | `DELETE /drive/items/{id}`                             | `DELETE /drive/root:/{path}`                     |
 | [Move an Item](items/move.md)                    | `PATCH /drive/items/{id}`                              | `PATCH /drive/root:/{path}`                      |
 | [Copy an Item](items/copy.md)                    | `POST /drive/items/{id}/action.copy`                   | `POST /drive/root:/{path}:/action.copy`          |

--- a/items/update.md
+++ b/items/update.md
@@ -1,4 +1,4 @@
-# Update an item on OneDrive
+# Update the metadata for an item in OneDrive
 
 Update the metadata for an item in OneDrive by ID or path. You can also use update to move
 an item to another parent by updating the item's **parentReference** facet.


### PR DESCRIPTION
Hey OneDrive team, I happen to notice this minor typo in your doc. So I come up with this PR.

It was previously documented as "Update an Item" or "Update an Item's contents", which is misleading. This API does NOT deal with item's content at all, it just changes the metadata.

Note: This PR branch is branched from (and by default will be merged into) the master branch. Not sure whether this is you folk's workflow. If you prefer to have bugfix PRs on dev branch only, do not hit that "merge" button directly.
