### PR TITLE
Update sharing_createLink.md

### DIFF
--- a/items/sharing_createLink.md
+++ b/items/sharing_createLink.md
@@ -16,8 +16,8 @@ to be able to create a sharing link.
 
 <!-- { "blockType": "ignored" } -->
 ```
-POST /drive/items/{item-id}/createLink
-POST /drive/root:/{item-path}:/createLink
+POST /drive/items/{item-id}/action.createLink
+POST /drive/root:/{item-path}:/action.createLink
 ```
 
 **Note:** This method has a different signature for Microsoft Graph and OneDrive API. See [OneDrive API endpoint differences](/direct-endpoint-differences.md) for more information.

--- a/items/sharing_createLink.md
+++ b/items/sharing_createLink.md
@@ -56,7 +56,7 @@ link available will be created.
 
 <!-- { "blockType": "request", "name": "create-link", "scopes": "files.readwrite", "target": "action" } -->
 ```
-POST /drive/items/{item-id}/createLink
+POST /drive/items/{item-id}/action.createLink
 Content-Type: application/json
 
 {
@@ -107,7 +107,7 @@ value of `organization`.
 
 <!-- { "blockType": "request", "name": "create-link-scoped", "scopes": "files.readwrite service.sharepoint" } -->
 ```
-POST /drive/items/{item-id}/createLink
+POST /drive/items/{item-id}/action.createLink
 Content-Type: application/json
 
 {


### PR DESCRIPTION
`/createLink` results in

```
StatusCodeError: 400 - "{\"error\":{\"code\":\"invalidRequest\",\"message\":\"API not found\"}}"
```

The correct endpoint seems to be `/action.createLink`