### PR TITLE
Update example

### DIFF
--- a/docs/controls/file-pickers/js-v72/open-file.md
+++ b/docs/controls/file-pickers/js-v72/open-file.md
@@ -36,7 +36,7 @@ As part of the `OneDrive.open(...)` method, you specify the options for how the 
     OneDrive.open(odOptions);
   }
 </script>
-<button onClick="launchOneDrivePicker">Open from OneDrive</button>
+<button onClick="launchOneDrivePicker()">Open from OneDrive</button>
 ```
 
 ### Picker options


### PR DESCRIPTION
Changed example to include parentheses on the launch function for the open button, otherwise it will not execute the function.