### PR TITLE
Fix duplicate header in Create Upload Session

### DIFF
--- a/docs/rest-api/api/driveitem_createuploadsession.md
+++ b/docs/rest-api/api/driveitem_createuploadsession.md
@@ -63,9 +63,9 @@ For example, to control the behavior if the filename is already taken, you can s
 |:-----------|:------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | *if-match* | etag  | If this request header is included and the eTag (or cTag) provided does not match the current etag on the item, a `412 Precondition Failed` errr response is returned. |
 
-### Response
+### Example
 
-The response to this request will provide the details of the newly created [uploadSession](../resources/uploadsession.md), which includes the URL used for uploading the parts of the file. 
+In this example, the app is creating an upload session with the filename `largefile.dat`. If the filename already exists, it will be automatically renamed.
 
 <!-- { "blockType": "request", "name": "upload-fragment-create-session", "scopes": "files.readwrite", "target": "action" } -->
 


### PR DESCRIPTION
There were two "Responses" in the "Create an upload session" section. Replaced the first one with a description of the Example to be consistent with the next section "Upload bytes to the upload session".