### PR TITLE
Link to Instance Attribute docs for upload metadata

### DIFF
--- a/docs/rest-api/api/driveitem_createuploadsession.md
+++ b/docs/rest-api/api/driveitem_createuploadsession.md
@@ -182,7 +182,7 @@ Content-Type: application/json
 ## Completing a file
 
 When the last byte range of a file is received the server will response with an `HTTP 201 Created` or `HTTP 200 OK`.
-The response body will also include the default property set for the **driveItem** representing the completed file.
+The response body will also include the default property set for the [driveItem](../resources/driveitem.md) representing the completed file.
 
 <!-- { "blockType": "request", "name": "upload-fragment-final", "scopes": "files.readwrite" } -->
 

--- a/docs/rest-api/api/driveitem_createuploadsession.md
+++ b/docs/rest-api/api/driveitem_createuploadsession.md
@@ -47,7 +47,7 @@ POST /users/{userId}/drive/items/{itemId}/createUploadSession
 No request body is required.
 However, you can specify a request body to provide additional data about the file being uploaded.
 
-For example, to control the behavior if the filename is already taken, you can specify the conflict behavior property in the body of the request.
+For example, to control the behavior if the filename is already taken, you can use an [Instance Attribute](../resources/driveitem.md#instance-attributes) to specify the conflict behavior property in the body of the request.
 
 ```json
 {


### PR DESCRIPTION
The only reference to Instance Attributes was in an obsolete upload doc, this clarifies how they're specified.