### PR TITLE
Update driveitem_createuploadsession.md

### DIFF
--- a/docs/rest-api/api/driveitem_createuploadsession.md
+++ b/docs/rest-api/api/driveitem_createuploadsession.md
@@ -50,7 +50,7 @@ However, you can specify an `item` property in the request body, providing addit
 <!-- { "blockType": "resource", "@odata.type": "microsoft.graph.driveItemUploadableProperties" } -->
 ```json
 {
-  "@microsoft.graph.conflictBehavior": "rename | fail | overwrite",
+  "@microsoft.graph.conflictBehavior": "rename | fail | replace",
   "description": "description",
   "fileSystemInfo": { "@odata.type": "microsoft.graph.fileSystemInfo" },
   "name": "filename.txt"


### PR DESCRIPTION
Fixing the bug in conflict behavior from the "overwrite" option that doesn't exist and changing it to "replace".