### PR TITLE
Adding intl metadata localization_priority to source markdown topics

### DIFF
--- a/docs/code-snippets/quickxorhash.md
+++ b/docs/code-snippets/quickxorhash.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: sample
 title: QuickXOR Hash Sample - OneDrive
+localization_priority: Normal
 ---
 # Code Snippets: QuickXorHash Algorithm
 

--- a/docs/controls/file-pickers/android/index.md
+++ b/docs/controls/file-pickers/android/index.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: overview
 title: File Picker SDK for Android - OneDrive
+localization_priority: Priority
 ---
 # OneDrive picker for Android
 

--- a/docs/controls/file-pickers/index.md
+++ b/docs/controls/file-pickers/index.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: overview
 title: OneDrive Controls for Developers
+localization_priority: Priority
 ---
 # Shared controls for OneDrive integration
 

--- a/docs/controls/file-pickers/js-v5/index.md
+++ b/docs/controls/file-pickers/js-v5/index.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: overview
+localization_priority: Normal
 ---
 # OneDrive file picker SDK for JavaScript
 

--- a/docs/controls/file-pickers/js-v6/index.md
+++ b/docs/controls/file-pickers/js-v6/index.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: overview
+localization_priority: Normal
 ---
 # OneDrive file picker SDK for JavaScript v6.0 overview
 

--- a/docs/controls/file-pickers/js-v6/open-file.md
+++ b/docs/controls/file-pickers/js-v6/open-file.md
@@ -2,6 +2,7 @@
 author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
+localization_priority: Normal
 ---
 # Opening files with the OneDrive file picker SDK for JavaScript
 

--- a/docs/controls/file-pickers/js-v6/save-file.md
+++ b/docs/controls/file-pickers/js-v6/save-file.md
@@ -2,6 +2,7 @@
 author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
+localization_priority: Normal
 ---
 # Saving files with the OneDrive file picker SDK for JavaScript
 

--- a/docs/controls/file-pickers/js-v7/index.md
+++ b/docs/controls/file-pickers/js-v7/index.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: overview
+localization_priority: Normal
 ---
 # OneDrive file picker for JavaScript v7.0 overview
 

--- a/docs/controls/file-pickers/js-v7/open-file.md
+++ b/docs/controls/file-pickers/js-v7/open-file.md
@@ -2,6 +2,7 @@
 author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
+localization_priority: Normal
 ---
 # Opening Files with the OneDrive File Picker JavaScript SDK v7.0
 

--- a/docs/controls/file-pickers/js-v7/save-file.md
+++ b/docs/controls/file-pickers/js-v7/save-file.md
@@ -2,6 +2,7 @@
 author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
+localization_priority: Normal
 ---
 # Saving Files with the OneDrive File Picker JavaScript SDK v7.0
 

--- a/docs/controls/file-pickers/js-v72/index.md
+++ b/docs/controls/file-pickers/js-v72/index.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: overview
 title: File Picker SDK for JavaScript - OneDrive
+localization_priority: Priority
 ---
 # OneDrive file picker for JavaScript v7.2 overview
 

--- a/docs/controls/file-pickers/js-v72/open-file.md
+++ b/docs/controls/file-pickers/js-v72/open-file.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Open from OneDrive in JavaScript
+localization_priority: Priority
 ---
 # Opening Files with the OneDrive File Picker JavaScript SDK v7.2
 

--- a/docs/controls/file-pickers/js-v72/save-file.md
+++ b/docs/controls/file-pickers/js-v72/save-file.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Save to OneDrive from JavaScript
+localization_priority: Priority
 ---
 # Saving Files with the OneDrive File Picker JavaScript SDK v7.2
 

--- a/docs/controls/file-pickers/react/customization.md
+++ b/docs/controls/file-pickers/react/customization.md
@@ -4,6 +4,7 @@ ms.author: naethell
 ms.date: 10/03/2018
 ms.topic: conceptual
 title: Customizing the File Browser
+localization_priority: Normal
 ---
 
 # Customizing the File Browser

--- a/docs/controls/file-pickers/react/index.md
+++ b/docs/controls/file-pickers/react/index.md
@@ -3,6 +3,7 @@ author: kevintcoughlin
 ms.author: keco
 ms.date: 10/02/2018
 ms.topic: overview
+localization_priority: Priority
 ---
 # Microsoft File Browser SDK (Preview)
 

--- a/docs/controls/file-pickers/react/select-files.md
+++ b/docs/controls/file-pickers/react/select-files.md
@@ -2,6 +2,7 @@
 author: kevintcoughlin
 ms.author: keco
 ms.date: 10/02/2018
+localization_priority: Normal
 ---
 
 # Selecting Files with the Microsoft File Browser SDK

--- a/docs/file-handlers/define-actions.md
+++ b/docs/file-handlers/define-actions.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: conceptual
 title: Add custom actions to files - OneDrive
+localization_priority: Normal
 ---
 # Specifying actions for file handlers 2.0
 

--- a/docs/file-handlers/index.md
+++ b/docs/file-handlers/index.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: overview
 title: Integrate with OneDrive file handlers
+localization_priority: Priority
 ---
 # Adding custom preview, open, and actions to files with File Handlers 2.0
 

--- a/docs/file-handlers/localization.md
+++ b/docs/file-handlers/localization.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Localize file handlers - OneDrive
+localization_priority: Normal
 ---
 # Localizing file handler strings
 

--- a/docs/file-handlers/register-manually.md
+++ b/docs/file-handlers/register-manually.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: conceptual
 topic: Register a file handler with Azure Active Directory
+localization_priority: Normal
 ---
 # How to: Register a file handler add-in manually
 

--- a/docs/file-handlers/reset-cache.md
+++ b/docs/file-handlers/reset-cache.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Reload OneDrive File Handlers
+localization_priority: Normal
 ---
 # Resetting the file handler cache
 

--- a/docs/file-handlers/resources.md
+++ b/docs/file-handlers/resources.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: File handler resource definitions
+localization_priority: Normal
 ---
 # Resource definitions for file handlers 2.0
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@ ms.date: 09/18/2017
 ms.topic: landing-page
 ms.prod: onedrive
 title: OneDrive for Developers
+localization_priority: Priority
 ---
 # OneDrive developer platform
 

--- a/docs/rest-api/api/activities_list.md
+++ b/docs/rest-api/api/activities_list.md
@@ -3,6 +3,7 @@ author: daspek
 ms.author: dspektor
 ms.date: 09/10/2017
 title: File Activities - OneDrive API
+localization_priority: Normal
 ---
 # Enumerate activities (preview)
 

--- a/docs/rest-api/api/drive_get.md
+++ b/docs/rest-api/api/drive_get.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Get Drive - OneDrive API
+localization_priority: Priority
 ---
 # Get Drive
 

--- a/docs/rest-api/api/drive_get_specialfolder.md
+++ b/docs/rest-api/api/drive_get_specialfolder.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Get Special Folders - OneDrive API
+localization_priority: Priority
 ---
 # Get a special folder by name
 

--- a/docs/rest-api/api/drive_list.md
+++ b/docs/rest-api/api/drive_list.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: List Drives - OneDrive API
+localization_priority: Priority
 ---
 # List available drives
 

--- a/docs/rest-api/api/drive_recent.md
+++ b/docs/rest-api/api/drive_recent.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: List Recent Files - OneDrive API
+localization_priority: Normal
 ---
 # List recent files
 

--- a/docs/rest-api/api/drive_sharedbyme.md
+++ b/docs/rest-api/api/drive_sharedbyme.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: List Shared Items - OneDrive API
+localization_priority: Normal
 ---
 # List items shared from a drive
 

--- a/docs/rest-api/api/drive_sharedwithme.md
+++ b/docs/rest-api/api/drive_sharedwithme.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: List Files Shared With Me - OneDrive API
+localization_priority: Priority
 ---
 # List items shared with the signed-in user
 

--- a/docs/rest-api/api/driveitem_checkin.md
+++ b/docs/rest-api/api/driveitem_checkin.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Check In Files - OneDrive API
+localization_priority: Priority
 ---
 # Check-in changes to a DriveItem resource
 

--- a/docs/rest-api/api/driveitem_checkout.md
+++ b/docs/rest-api/api/driveitem_checkout.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Check Out Files - OneDrive API
+localization_priority: Normal
 ---
 # Check-out a DriveItem resource
 

--- a/docs/rest-api/api/driveitem_copy.md
+++ b/docs/rest-api/api/driveitem_copy.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Copy a file or folder - OneDrive API
+localization_priority: Normal
 ---
 # Copy a DriveItem
 

--- a/docs/rest-api/api/driveitem_createlink.md
+++ b/docs/rest-api/api/driveitem_createlink.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Share a file with a link - OneDrive API
+localization_priority: Priority
 ---
 # Create a sharing link for a DriveItem
 

--- a/docs/rest-api/api/driveitem_createuploadsession.md
+++ b/docs/rest-api/api/driveitem_createuploadsession.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Resumable file upload - OneDrive API
+localization_priority: Priority
 ---
 # Upload large files with an upload session
 

--- a/docs/rest-api/api/driveitem_delete.md
+++ b/docs/rest-api/api/driveitem_delete.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Delete a file or folder - OneDrive API
+localization_priority: Normal
 ---
 # Delete a DriveItem
 

--- a/docs/rest-api/api/driveitem_delta.md
+++ b/docs/rest-api/api/driveitem_delta.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Sync the contents of a drive - OneDrive API
+localization_priority: Priority
 ---
 # Track changes for a Drive
 

--- a/docs/rest-api/api/driveitem_get.md
+++ b/docs/rest-api/api/driveitem_get.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Get a file or folder - OneDrive API
+localization_priority: Priority
 ---
 # Get a DriveItem resource
 

--- a/docs/rest-api/api/driveitem_get_content.md
+++ b/docs/rest-api/api/driveitem_get_content.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Download a file - OneDrive API
+localization_priority: Priority
 ---
 # Download the contents of a DriveItem
 

--- a/docs/rest-api/api/driveitem_get_content_format.md
+++ b/docs/rest-api/api/driveitem_get_content_format.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Convert to other formats - OneDrive API
+localization_priority: Priority
 ---
 # Download a file in another format
 

--- a/docs/rest-api/api/driveitem_invite.md
+++ b/docs/rest-api/api/driveitem_invite.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Send an invite to access an item - OneDrive API
+localization_priority: Priority
 ---
 # Send a sharing invitation
 

--- a/docs/rest-api/api/driveitem_list_children.md
+++ b/docs/rest-api/api/driveitem_list_children.md
@@ -1,8 +1,9 @@
-﻿---
+---
 author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: List the contents of a folder - OneDrive API
+localization_priority: Priority
 ---
 # List children of a driveItem
 

--- a/docs/rest-api/api/driveitem_list_permissions.md
+++ b/docs/rest-api/api/driveitem_list_permissions.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: List who has access to a file - OneDrive API
+localization_priority: Priority
 ---
 # List sharing permissions on a DriveItem
 

--- a/docs/rest-api/api/driveitem_list_thumbnails.md
+++ b/docs/rest-api/api/driveitem_list_thumbnails.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Retrieve thumbnails for a file or folder - OneDrive API
+localization_priority: Priority
 ---
 # List thumbnails for a DriveItem
 

--- a/docs/rest-api/api/driveitem_list_versions.md
+++ b/docs/rest-api/api/driveitem_list_versions.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: List versions of a file - OneDrive API
+localization_priority: Normal
 ---
 # Listing versions of a DriveItem
 

--- a/docs/rest-api/api/driveitem_move.md
+++ b/docs/rest-api/api/driveitem_move.md
@@ -1,8 +1,9 @@
-﻿---
+---
 author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Move a file or folder - OneDrive API
+localization_priority: Normal
 ---
 # Move a DriveItem to a new folder
 

--- a/docs/rest-api/api/driveitem_post_children.md
+++ b/docs/rest-api/api/driveitem_post_children.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Create a new folder - OneDrive API
+localization_priority: Priority
 ---
 # Create a new folder in a drive
 

--- a/docs/rest-api/api/driveitem_post_content.md
+++ b/docs/rest-api/api/driveitem_post_content.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Upload contents and metadata - OneDrive API
+localization_priority: Normal
 ---
 # Multipart upload to OneDrive using POST
 

--- a/docs/rest-api/api/driveitem_preview.md
+++ b/docs/rest-api/api/driveitem_preview.md
@@ -3,6 +3,7 @@ author: kevinlam
 ms.author: kevinlam
 ms.date: 2/23/2018
 title: Get short-lived embeddable link for preview purposes - OneDrive API
+localization_priority: Normal
 ---
 # Embeddable file previews
 This action allows you to obtain short-lived embeddable URLs for an item.

--- a/docs/rest-api/api/driveitem_put_content.md
+++ b/docs/rest-api/api/driveitem_put_content.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Upload small files - OneDrive API
+localization_priority: Priority
 ---
 # Upload or replace the contents of a DriveItem
 

--- a/docs/rest-api/api/driveitem_put_thumbnailset_content.md
+++ b/docs/rest-api/api/driveitem_put_thumbnailset_content.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Set a thumbnail on a file - OneDrive API
+localization_priority: Normal
 ---
 # Upload a custom thumbnail for a DriveItem
 

--- a/docs/rest-api/api/driveitem_search.md
+++ b/docs/rest-api/api/driveitem_search.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Search for files - OneDrive API
+localization_priority: Priority
 ---
 # Search for a DriveItems within a drive
 

--- a/docs/rest-api/api/driveitem_update.md
+++ b/docs/rest-api/api/driveitem_update.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Update a file or folder - OneDrive API
+localization_priority: Priority
 ---
 # Update DriveItem properties
 

--- a/docs/rest-api/api/driveitem_upload_url.md
+++ b/docs/rest-api/api/driveitem_upload_url.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Upload from a URL - OneDrive API
+localization_priority: Priority
 ---
 # Upload an item to OneDrive from a URL (preview)
 

--- a/docs/rest-api/api/driveitemversion_get.md
+++ b/docs/rest-api/api/driveitemversion_get.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Get a previous version - OneDrive API
+localization_priority: Normal
 ---
 # Get a DriveItemVersion resource
 

--- a/docs/rest-api/api/driveitemversion_get_contents.md
+++ b/docs/rest-api/api/driveitemversion_get_contents.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Download a previous version - OneDrive API
+localization_priority: Normal
 ---
 # Download contents of a DriveItemVersion resource
 

--- a/docs/rest-api/api/driveitemversion_restore.md
+++ b/docs/rest-api/api/driveitemversion_restore.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Restore a previous version - OneDrive API
+localization_priority: Normal
 ---
 # Restore a previous version of a DriveItem
 

--- a/docs/rest-api/api/list_create.md
+++ b/docs/rest-api/api/list_create.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/11/2017
 title: Create a SharePoint List
+localization_priority: Normal
 ---
 # Create a new list
 

--- a/docs/rest-api/api/list_get.md
+++ b/docs/rest-api/api/list_get.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/11/2017
 title: Get a SharePoint list
+localization_priority: Normal
 ---
 # Get metadata for a list
 

--- a/docs/rest-api/api/list_list.md
+++ b/docs/rest-api/api/list_list.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/11/2017
 title: List the SharePoint lists in a site
+localization_priority: Normal
 ---
 # Enumerate lists in a site
 

--- a/docs/rest-api/api/listitem_create.md
+++ b/docs/rest-api/api/listitem_create.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/11/2017
 title: Create a new entry in a SharePoint list
+localization_priority: Normal
 ---
 # Create a new item in a list
 

--- a/docs/rest-api/api/listitem_delete.md
+++ b/docs/rest-api/api/listitem_delete.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/11/2017
 title: Delete an entry from a SharePoint list
+localization_priority: Normal
 ---
 # Delete an item from a list
 

--- a/docs/rest-api/api/listitem_get.md
+++ b/docs/rest-api/api/listitem_get.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/11/2017
 title: Get an entry from a SharePoint list
+localization_priority: Normal
 ---
 # Get an item in a list
 

--- a/docs/rest-api/api/listitem_list.md
+++ b/docs/rest-api/api/listitem_list.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/11/2017
 title: Retrieve items from a SharePoint list
+localization_priority: Normal
 ---
 # Enumerate items in a list
 

--- a/docs/rest-api/api/listitem_list_versions.md
+++ b/docs/rest-api/api/listitem_list_versions.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Get a previous version of a SharePoint list record
+localization_priority: Normal
 ---
 # Listing versions of a ListItem
 

--- a/docs/rest-api/api/listitem_update.md
+++ b/docs/rest-api/api/listitem_update.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/11/2017
 title: Update a record in a SharePoint list
+localization_priority: Normal
 ---
 # Update an item in a list
 

--- a/docs/rest-api/api/listitemversion_get.md
+++ b/docs/rest-api/api/listitemversion_get.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Get a previous version of a list item - SharePoint API
+localization_priority: Priority
 ---
 # Get a ListItemVersion resource
 

--- a/docs/rest-api/api/listitemversion_restore.md
+++ b/docs/rest-api/api/listitemversion_restore.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Restore a previous version of a SharePoint list item
+localization_priority: Normal
 ---
 # Restore a previous version of a ListItem
 

--- a/docs/rest-api/api/permission_delete.md
+++ b/docs/rest-api/api/permission_delete.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Remove access to an item - OneDrive API
+localization_priority: Normal
 ---
 # Delete a sharing permission from a file or folder
 

--- a/docs/rest-api/api/permission_get.md
+++ b/docs/rest-api/api/permission_get.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Get permissions - OneDrive API
+localization_priority: Normal
 ---
 # Get sharing permission for a file or folder
 

--- a/docs/rest-api/api/permission_update.md
+++ b/docs/rest-api/api/permission_update.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Change sharing permissions - OneDrive API
+localization_priority: Normal
 ---
 # Update sharing permission
 

--- a/docs/rest-api/api/shares_get.md
+++ b/docs/rest-api/api/shares_get.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Access shared items - OneDrive API
+localization_priority: Priority
 ---
 # Accessing shared DriveItems
 

--- a/docs/rest-api/api/site_get.md
+++ b/docs/rest-api/api/site_get.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Get a SharePoint Site - OneDrive API
+localization_priority: Normal
 ---
 # Get a site resource
 

--- a/docs/rest-api/api/site_getbypath.md
+++ b/docs/rest-api/api/site_getbypath.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Get SharePoint site by path - OneDrive API
+localization_priority: Normal
 ---
 # Get a site resource by path
 

--- a/docs/rest-api/api/site_list_subsites.md
+++ b/docs/rest-api/api/site_list_subsites.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: List the subsites for a SharePoint site - OneDrive API
+localization_priority: Normal
 ---
 # Enumerate subsites
 

--- a/docs/rest-api/api/site_search.md
+++ b/docs/rest-api/api/site_search.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Find SharePoint sites by keyword - OneDrive API
+localization_priority: Normal
 ---
 # Search for sites
 

--- a/docs/rest-api/api/subscription_delete.md
+++ b/docs/rest-api/api/subscription_delete.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Remove a webhook subscription - OneDrive API
+localization_priority: Normal
 ---
 # Delete subscription
 

--- a/docs/rest-api/api/subscription_post_subscriptions.md
+++ b/docs/rest-api/api/subscription_post_subscriptions.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Create a webhook subscription - OneDrive API
+localization_priority: Normal
 ---
 # Create subscription
 

--- a/docs/rest-api/api/subscription_update.md
+++ b/docs/rest-api/api/subscription_update.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Update a webhook subscription - OneDrive API
+localization_priority: Normal
 ---
 # Update subscription
 

--- a/docs/rest-api/concepts/addressing-driveitems.md
+++ b/docs/rest-api/concepts/addressing-driveitems.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: conceptual
 title: How to address resources - OneDrive API
+localization_priority: Priority
 ---
 # Addressing resources in a drive on OneDrive
 

--- a/docs/rest-api/concepts/case-sensitivity.md
+++ b/docs/rest-api/concepts/case-sensitivity.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: conceptual
 title: Understand case sensitivity - OneDrive API
+localization_priority: Normal
 ---
 # Case sensitivity notes
 

--- a/docs/rest-api/concepts/custom-metadata-facets.md
+++ b/docs/rest-api/concepts/custom-metadata-facets.md
@@ -4,6 +4,7 @@ ms.author: dspektor
 ms.date: 09/10/2017
 ms.topic: conceptual
 title: Add custom metadata to items - OneDrive API
+localization_priority: Normal
 ---
 # Custom facets (preview)
 

--- a/docs/rest-api/concepts/direct-endpoint-differences.md
+++ b/docs/rest-api/concepts/direct-endpoint-differences.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: conceptual
 title: Understand differences between OneDrive API and Microsoft Graph
+localization_priority: Priority
 ---
 # OneDrive API Endpoint Differences
 

--- a/docs/rest-api/concepts/errors.md
+++ b/docs/rest-api/concepts/errors.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Error responses - OneDrive API
+localization_priority: Priority
 ---
 # Common error responses and codes
 

--- a/docs/rest-api/concepts/filtering-results.md
+++ b/docs/rest-api/concepts/filtering-results.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: conceptual
 title: How to filter items - OneDrive API
+localization_priority: Normal
 ---
 # Filtering a collection
 

--- a/docs/rest-api/concepts/http-verb-tunneling.md
+++ b/docs/rest-api/concepts/http-verb-tunneling.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: conceptual
 title: Tunneling HTTP verbs - OneDrive API
+localization_priority: Normal
 ---
 # Using additional HTTP verbs when your client is limited
 

--- a/docs/rest-api/concepts/index.md
+++ b/docs/rest-api/concepts/index.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: OneDrive API concepts overview
+localization_priority: Priority
 ---
 # OneDrive integration concepts
 

--- a/docs/rest-api/concepts/long-running-actions.md
+++ b/docs/rest-api/concepts/long-running-actions.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: conceptual
 title: Calling long running actions - OneDrive API
+localization_priority: Normal
 ---
 # Working with APIs that make take a long time to complete
 

--- a/docs/rest-api/concepts/migrating-from-live-sdk.md
+++ b/docs/rest-api/concepts/migrating-from-live-sdk.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 10/16/2017
 title: Migrating from Live SDK to Microsoft Graph
+localization_priority: Normal
 ---
 # Migrating from Live SDK to Microsoft Graph
 

--- a/docs/rest-api/concepts/optional-query-parameters.md
+++ b/docs/rest-api/concepts/optional-query-parameters.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: conceptual
 title: Modifying responses with query parameters - OneDrive API
+localization_priority: Priority
 ---
 # Using query parameters to change the shape of a response
 

--- a/docs/rest-api/concepts/permissions_reference.md
+++ b/docs/rest-api/concepts/permissions_reference.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Understanding OneDrive API permission scopes
+localization_priority: Priority
 ---
 # Permissions for OneDrive API
 

--- a/docs/rest-api/concepts/sharing.md
+++ b/docs/rest-api/concepts/sharing.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: conceptual
 title: Sharing items - OneDrive API
+localization_priority: Normal
 ---
 # Sharing items in OneDrive and SharePoint
 

--- a/docs/rest-api/concepts/special-folders-appfolder.md
+++ b/docs/rest-api/concepts/special-folders-appfolder.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: conceptual
 title: What is an App Folder - OneDrive API
+localization_priority: Priority
 ---
 # Using an App Folder to store user content without access to all files
 

--- a/docs/rest-api/concepts/upload.md
+++ b/docs/rest-api/concepts/upload.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: conceptual
 title: Uploading files - OneDrive API
+localization_priority: Priority
 ---
 # Upload contents for an item on OneDrive
 

--- a/docs/rest-api/concepts/using-sharing-links.md
+++ b/docs/rest-api/concepts/using-sharing-links.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: conceptual
 title: Accessing shared files and folders - OneDrive API
+localization_priority: Priority
 ---
 # Using remote items to access shared files and folders
 

--- a/docs/rest-api/concepts/using-webhooks.md
+++ b/docs/rest-api/concepts/using-webhooks.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: conceptual
 title: Webhook notifications - OneDrive API
+localization_priority: Priority
 ---
 # Using webhooks to receive service-to-service notifications
 

--- a/docs/rest-api/concepts/webhook-receiver-validation-request.md
+++ b/docs/rest-api/concepts/webhook-receiver-validation-request.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: conceptual
 title: Validating webhook subscriptions - OneDrive API
+localization_priority: Normal
 ---
 # Handling webhook validation requests
 

--- a/docs/rest-api/concepts/working-with-cors.md
+++ b/docs/rest-api/concepts/working-with-cors.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: conceptual
 title: CORS support - OneDrive API
+localization_priority: Normal
 ---
 # Using the OneDrive API in JavaScript apps (CORS support)
 

--- a/docs/rest-api/getting-started/aad-oauth.md
+++ b/docs/rest-api/getting-started/aad-oauth.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: conceptual
 title: Using Azure Active Directory to sign-in - OneDrive API
+localization_priority: Priority
 ---
 # OneDrive for Business authentication and sign in
 

--- a/docs/rest-api/getting-started/app-registration-server.md
+++ b/docs/rest-api/getting-started/app-registration-server.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: conceptual
 title: Create an app with SharePoint Server 2016 - OneDrive API
+localization_priority: Normal
 ---
 # Registering your app to use OneDrive API with SharePoint Server 2016
 

--- a/docs/rest-api/getting-started/app-registration.md
+++ b/docs/rest-api/getting-started/app-registration.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: conceptual
 title: Create an app with Microsoft Graph - OneDrive API
+localization_priority: Priority
 ---
 # Registering your app for Microsoft Graph
 

--- a/docs/rest-api/getting-started/authentication.md
+++ b/docs/rest-api/getting-started/authentication.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: conceptual
 title: Sign-in and authorization - OneDrive API
+localization_priority: Priority
 ---
 # Authorizing your app to access OneDrive
 

--- a/docs/rest-api/getting-started/graph-oauth.md
+++ b/docs/rest-api/getting-started/graph-oauth.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: conceptual
 title: Authorization for OneDrive API via Microsoft Graph
+localization_priority: Priority
 ---
 # Authorization and sign-in for OneDrive in Microsoft Graph
 

--- a/docs/rest-api/getting-started/index.md
+++ b/docs/rest-api/getting-started/index.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: get-started-article
 title: Get started using OneDrive API
+localization_priority: Priority
 ---
 # Getting started with OneDrive API
 

--- a/docs/rest-api/getting-started/msa-oauth.md
+++ b/docs/rest-api/getting-started/msa-oauth.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: conceptual
 title: Authorization for OneDrive API for Microsoft Accounts
+localization_priority: Priority
 ---
 # OneDrive authentication and sign-in
 

--- a/docs/rest-api/getting-started/release-notes.md
+++ b/docs/rest-api/getting-started/release-notes.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: OneDrive API release notes
+localization_priority: Normal
 ---
 # Release notes for using Microsoft Graph with OneDrive for Business and SharePoint
 

--- a/docs/rest-api/getting-started/sharepoint-server-2016.md
+++ b/docs/rest-api/getting-started/sharepoint-server-2016.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: get-started-article
 title: Get started using OneDrive API with SharePoint Server 2016
+localization_priority: Normal
 ---
 # Getting started with OneDrive API with SharePoint Server 2016
 

--- a/docs/rest-api/index.md
+++ b/docs/rest-api/index.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: overview
 title: Access OneDrive and SharePoint via Microsoft Graph API
+localization_priority: Priority
 ---
 # OneDrive and SharePoint in Microsoft Graph
 

--- a/docs/rest-api/resources/asyncJobStatus.md
+++ b/docs/rest-api/resources/asyncJobStatus.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: AsyncJobStatus - OneDrive API
+localization_priority: Normal
 ---
 # AsyncJobStatus resource
 

--- a/docs/rest-api/resources/audio.md
+++ b/docs/rest-api/resources/audio.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Audio - OneDrive API
+localization_priority: Normal
 ---
 # Audio facet
 

--- a/docs/rest-api/resources/baseItem.md
+++ b/docs/rest-api/resources/baseItem.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: BaseItem - OneDrive API
+localization_priority: Normal
 ---
 # BaseItem resource type
 

--- a/docs/rest-api/resources/baseitemversion.md
+++ b/docs/rest-api/resources/baseitemversion.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/17/2017
 title: BaseItemVersion - OneDrive API
+localization_priority: Normal
 ---
 # BaseItemVersion resource type
 

--- a/docs/rest-api/resources/booleancolumn.md
+++ b/docs/rest-api/resources/booleancolumn.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/11/2017
 title: BooleanColumn - OneDrive API
+localization_priority: Normal
 ---
 # BooleanColumn resource type
 

--- a/docs/rest-api/resources/calculatedcolumn.md
+++ b/docs/rest-api/resources/calculatedcolumn.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/11/2017
 title: CalculatedColumn - OneDrive API
+localization_priority: Normal
 ---
 # CalculatedColumn resource type
 

--- a/docs/rest-api/resources/choicecolumn.md
+++ b/docs/rest-api/resources/choicecolumn.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/11/2017
 title: ChoiceColumn - OneDrive API
+localization_priority: Normal
 ---
 # ChoiceColumn resource type
 

--- a/docs/rest-api/resources/columndefinition.md
+++ b/docs/rest-api/resources/columndefinition.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/11/2017
 title: ColumnDefinition - OneDrive API
+localization_priority: Normal
 ---
 # ColumnDefinition resource
 

--- a/docs/rest-api/resources/columnlink.md
+++ b/docs/rest-api/resources/columnlink.md
@@ -3,6 +3,7 @@ author: daspek
 ms.author: dspektor
 ms.date: 09/12/2017
 title: ColumnLink - OneDrive API
+localization_priority: Normal
 ---
 # ColumnLink resource type
 

--- a/docs/rest-api/resources/commentaction.md
+++ b/docs/rest-api/resources/commentaction.md
@@ -3,6 +3,7 @@ author: daspek
 ms.author: dspektor
 ms.date: 09/14/2017
 title: CommentAction - OneDrive API
+localization_priority: Normal
 ---
 # CommentAction resource type
 

--- a/docs/rest-api/resources/contenttype.md
+++ b/docs/rest-api/resources/contenttype.md
@@ -3,6 +3,7 @@ author: daspek
 ms.author: dspektor
 ms.date: 09/12/2017
 title: ContentType - OneDrive API
+localization_priority: Normal
 ---
 # ContentType resource type
 

--- a/docs/rest-api/resources/contenttypeinfo.md
+++ b/docs/rest-api/resources/contenttypeinfo.md
@@ -3,6 +3,7 @@ author: daspek
 ms.author: dspektor
 ms.date: 09/12/2017
 title: ContentTypeInfo - OneDrive API
+localization_priority: Normal
 ---
 # ContentTypeInfo resource type
 

--- a/docs/rest-api/resources/contenttypeorder.md
+++ b/docs/rest-api/resources/contenttypeorder.md
@@ -3,6 +3,7 @@ author: daspek
 ms.author: dspektor
 ms.date: 09/13/2017
 title: ContentTypeOrder - OneDrive API
+localization_priority: Normal
 ---
 # ContentTypeOrder resource type
 

--- a/docs/rest-api/resources/createaction.md
+++ b/docs/rest-api/resources/createaction.md
@@ -3,6 +3,7 @@ author: daspek
 ms.author: dspektor
 ms.date: 09/14/2017
 title: CreateAction - OneDrive API
+localization_priority: Normal
 ---
 # CreateAction resource type
 

--- a/docs/rest-api/resources/currencycolumn.md
+++ b/docs/rest-api/resources/currencycolumn.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/11/2017
 title: CurrencyColumn - OneDrive API
+localization_priority: Normal
 ---
 # CurrencyColumn resource type
 

--- a/docs/rest-api/resources/datetimecolumn.md
+++ b/docs/rest-api/resources/datetimecolumn.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/11/2017
 title: DateTimeColumn - OneDrive API
+localization_priority: Normal
 ---
 # DateTimeColumn resource type
 

--- a/docs/rest-api/resources/defaultcolumnvalue.md
+++ b/docs/rest-api/resources/defaultcolumnvalue.md
@@ -3,6 +3,7 @@ author: daspek
 ms.author: dspektor
 ms.date: 09/12/2017
 title: DefaultColumnValue - OneDrive API
+localization_priority: Normal
 ---
 # DefaultColumnValue resource type
 

--- a/docs/rest-api/resources/deleteaction.md
+++ b/docs/rest-api/resources/deleteaction.md
@@ -3,6 +3,7 @@ author: daspek
 ms.author: dspektor
 ms.date: 09/14/2017
 title: DeleteAction - OneDrive API
+localization_priority: Normal
 ---
 # DeleteAction resource type
 

--- a/docs/rest-api/resources/deleted.md
+++ b/docs/rest-api/resources/deleted.md
@@ -1,8 +1,9 @@
-﻿---
+---
 author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Deleted - OneDrive API
+localization_priority: Normal
 ---
 # Deleted facet
 

--- a/docs/rest-api/resources/drive.md
+++ b/docs/rest-api/resources/drive.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Drive - OneDrive API
+localization_priority: Priority
 ---
 # Drive resource type
 

--- a/docs/rest-api/resources/driveitem.md
+++ b/docs/rest-api/resources/driveitem.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: DriveItem - OneDrive API
+localization_priority: Priority
 ---
 # DriveItem resource type
 

--- a/docs/rest-api/resources/driveitemversion.md
+++ b/docs/rest-api/resources/driveitemversion.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/17/2017
 title: DriveItemVersion - OneDrive API
+localization_priority: Normal
 ---
 # DriveItemVersion resource type
 

--- a/docs/rest-api/resources/driverecipient.md
+++ b/docs/rest-api/resources/driverecipient.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: DriveRecipient - OneDrive API
+localization_priority: Normal
 ---
 # DriveRecipient resource
 

--- a/docs/rest-api/resources/editaction.md
+++ b/docs/rest-api/resources/editaction.md
@@ -3,6 +3,7 @@ author: daspek
 ms.author: dspektor
 ms.date: 09/14/2017
 title: EditAction - OneDrive API
+localization_priority: Normal
 ---
 # EditAction resource type
 

--- a/docs/rest-api/resources/error.md
+++ b/docs/rest-api/resources/error.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Error - OneDrive API
+localization_priority: Normal
 ---
 # Error resource
 

--- a/docs/rest-api/resources/fieldvalueset.md
+++ b/docs/rest-api/resources/fieldvalueset.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/11/2017
 title: FieldValueSet - OneDrive API
+localization_priority: Normal
 ---
 # FieldValueSet resource
 

--- a/docs/rest-api/resources/file.md
+++ b/docs/rest-api/resources/file.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: File - OneDrive API
+localization_priority: Normal
 ---
 # File resource type
 

--- a/docs/rest-api/resources/filesysteminfo.md
+++ b/docs/rest-api/resources/filesysteminfo.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: FileSystemInfo - OneDrive API
+localization_priority: Normal
 ---
 # FileSystemInfo facet
 

--- a/docs/rest-api/resources/folder.md
+++ b/docs/rest-api/resources/folder.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Folder - OneDrive API
+localization_priority: Normal
 ---
 # Folder resource type
 

--- a/docs/rest-api/resources/folderview.md
+++ b/docs/rest-api/resources/folderview.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: FolderView - OneDrive API
+localization_priority: Normal
 ---
 # FolderView resource type
 

--- a/docs/rest-api/resources/geocoordinates.md
+++ b/docs/rest-api/resources/geocoordinates.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: GeoCoordinates - OneDrive API
+localization_priority: Normal
 ---
 # GeoCoordinates resource type
 

--- a/docs/rest-api/resources/hashes.md
+++ b/docs/rest-api/resources/hashes.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Hashes - OneDrive API
+localization_priority: Normal
 ---
 # Hashes resource type
 

--- a/docs/rest-api/resources/identity.md
+++ b/docs/rest-api/resources/identity.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Identity - OneDrive API
+localization_priority: Normal
 ---
 # Identity resource type
 

--- a/docs/rest-api/resources/identitySet.md
+++ b/docs/rest-api/resources/identitySet.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: IdentitySet - OneDrive API
+localization_priority: Normal
 ---
 # IdentitySet resource type
 

--- a/docs/rest-api/resources/image.md
+++ b/docs/rest-api/resources/image.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Image - OneDrive API
+localization_priority: Normal
 ---
 # Image resource type
 

--- a/docs/rest-api/resources/index.md
+++ b/docs/rest-api/resources/index.md
@@ -1,8 +1,9 @@
-﻿---
+---
 author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Resources and Facets - OneDrive API
+localization_priority: Priority
 ---
 # Resources
 

--- a/docs/rest-api/resources/itemPreviewInfo.md
+++ b/docs/rest-api/resources/itemPreviewInfo.md
@@ -3,6 +3,7 @@ author: kevinlam
 ms.author: kevinlam
 ms.date: 3/16/2018
 title: ItemPreviewInfo - OneDrive API
+localization_priority: Normal
 ---
 # ItemPreviewInfo resource type
 

--- a/docs/rest-api/resources/itemReference.md
+++ b/docs/rest-api/resources/itemReference.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: ItemReference - OneDrive API
+localization_priority: Normal
 ---
 # ItemReference resource type
 

--- a/docs/rest-api/resources/itemactionset.md
+++ b/docs/rest-api/resources/itemactionset.md
@@ -3,6 +3,7 @@ author: daspek
 ms.author: dspektor
 ms.date: 09/14/2017
 title: ItemActionSet - OneDrive API
+localization_priority: Normal
 ---
 # ItemActionSet resource type
 

--- a/docs/rest-api/resources/itemactivity.md
+++ b/docs/rest-api/resources/itemactivity.md
@@ -3,6 +3,7 @@ author: daspek
 ms.author: dspektor
 ms.date: 09/14/2017
 title: ItemActivity - OneDrive API
+localization_priority: Normal
 ---
 # ItemActivity resource type
 

--- a/docs/rest-api/resources/itemactivitytimeset.md
+++ b/docs/rest-api/resources/itemactivitytimeset.md
@@ -3,6 +3,7 @@ author: daspek
 ms.author: dspektor
 ms.date: 09/14/2017
 title: ItemActivityTimeSet - OneDrive API
+localization_priority: Normal
 ---
 # ItemActivityTimeSet resource type
 

--- a/docs/rest-api/resources/list.md
+++ b/docs/rest-api/resources/list.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/11/2017
 title: List - OneDrive API
+localization_priority: Priority
 ---
 # List resource
 

--- a/docs/rest-api/resources/listinfo.md
+++ b/docs/rest-api/resources/listinfo.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/11/2017
 title: ListInfo - OneDrive API
+localization_priority: Normal
 ---
 # ListInfo resource
 

--- a/docs/rest-api/resources/listitem.md
+++ b/docs/rest-api/resources/listitem.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/11/2017
 title: ListItem - OneDrive API
+localization_priority: Normal
 ---
 # ListItem resource
 

--- a/docs/rest-api/resources/listitemversion.md
+++ b/docs/rest-api/resources/listitemversion.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/17/2017
 title: ListItemVersion - OneDrive API
+localization_priority: Normal
 ---
 # ListItemVersion resource type
 

--- a/docs/rest-api/resources/lookupcolumn.md
+++ b/docs/rest-api/resources/lookupcolumn.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/11/2017
 title: LookupColumn - OneDrive API
+localization_priority: Normal
 ---
 # LookupColumn resource type
 

--- a/docs/rest-api/resources/malware.md
+++ b/docs/rest-api/resources/malware.md
@@ -3,6 +3,7 @@ author: ificator
 ms.author: bcleaver
 ms.date: 01/26/2018
 title: Malware - OneDrive API
+localization_priority: Normal
 ---
 # Malware resource type
 

--- a/docs/rest-api/resources/mentionaction.md
+++ b/docs/rest-api/resources/mentionaction.md
@@ -3,6 +3,7 @@ author: daspek
 ms.author: dspektor
 ms.date: 09/14/2017
 title: MentionAction - OneDrive API
+localization_priority: Normal
 ---
 # MentionAction resource type
 

--- a/docs/rest-api/resources/moveaction.md
+++ b/docs/rest-api/resources/moveaction.md
@@ -3,6 +3,7 @@ author: daspek
 ms.author: dspektor
 ms.date: 09/14/2017
 title: MoveAction - OneDrive API
+localization_priority: Normal
 ---
 # MoveAction resource type
 

--- a/docs/rest-api/resources/numbercolumn.md
+++ b/docs/rest-api/resources/numbercolumn.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/11/2017
 title: NumberColumn - OneDrive API
+localization_priority: Normal
 ---
 # NumberColumn resource type
 

--- a/docs/rest-api/resources/package.md
+++ b/docs/rest-api/resources/package.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Package - OneDrive API
+localization_priority: Normal
 ---
 # Package resource type
 

--- a/docs/rest-api/resources/permission.md
+++ b/docs/rest-api/resources/permission.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Permission - OneDrive API
+localization_priority: Priority
 ---
 # Permission resource type
 

--- a/docs/rest-api/resources/personorgroupcolumn.md
+++ b/docs/rest-api/resources/personorgroupcolumn.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/11/2017
 title: PersonOrGroupColumn - OneDrive API
+localization_priority: Normal
 ---
 # PersonOrGroupColumn resource type
 

--- a/docs/rest-api/resources/photo.md
+++ b/docs/rest-api/resources/photo.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Photo - OneDrive API
+localization_priority: Normal
 ---
 # Photo resource type
 

--- a/docs/rest-api/resources/publicationfacet.md
+++ b/docs/rest-api/resources/publicationfacet.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: PublicationFacet - OneDrive API
+localization_priority: Normal
 ---
 # PublicationFacet resource type
 

--- a/docs/rest-api/resources/quota.md
+++ b/docs/rest-api/resources/quota.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Quota - OneDrive API
+localization_priority: Normal
 ---
 # Quota resource type
 

--- a/docs/rest-api/resources/remoteitem.md
+++ b/docs/rest-api/resources/remoteitem.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: RemoteItem - OneDrive API
+localization_priority: Normal
 ---
 # RemoteItem resource type
 

--- a/docs/rest-api/resources/renameaction.md
+++ b/docs/rest-api/resources/renameaction.md
@@ -3,6 +3,7 @@ author: daspek
 ms.author: dspektor
 ms.date: 09/14/2017
 title: RenameAction - OneDrive API
+localization_priority: Normal
 ---
 # RenameAction resource type
 

--- a/docs/rest-api/resources/restoreaction.md
+++ b/docs/rest-api/resources/restoreaction.md
@@ -3,6 +3,7 @@ author: daspek
 ms.author: dspektor
 ms.date: 09/14/2017
 title: RestoreAction - OneDrive API
+localization_priority: Normal
 ---
 # RestoreAction resource type
 

--- a/docs/rest-api/resources/root.md
+++ b/docs/rest-api/resources/root.md
@@ -1,8 +1,9 @@
-﻿---
+---
 author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Root - OneDrive API
+localization_priority: Normal
 ---
 # Root resource type
 

--- a/docs/rest-api/resources/searchresult.md
+++ b/docs/rest-api/resources/searchresult.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: SearchResult - OneDrive API
+localization_priority: Normal
 ---
 # SearchResult resource type
 

--- a/docs/rest-api/resources/shareaction.md
+++ b/docs/rest-api/resources/shareaction.md
@@ -3,6 +3,7 @@ author: daspek
 ms.author: dspektor
 ms.date: 09/14/2017
 title: ShareAction - OneDrive API
+localization_priority: Normal
 ---
 # ShareAction resource type
 

--- a/docs/rest-api/resources/shared.md
+++ b/docs/rest-api/resources/shared.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Shared - OneDrive API
+localization_priority: Normal
 ---
 # Shared resource type
 

--- a/docs/rest-api/resources/shareddriveitem.md
+++ b/docs/rest-api/resources/shareddriveitem.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: SharedDriveItem - OneDrive API
+localization_priority: Normal
 ---
 # SharedDriveItem resource type
 

--- a/docs/rest-api/resources/sharepointids.md
+++ b/docs/rest-api/resources/sharepointids.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: SharePointIds - OneDrive API
+localization_priority: Normal
 ---
 # SharePointIds resource type
 

--- a/docs/rest-api/resources/sharinginvitation.md
+++ b/docs/rest-api/resources/sharinginvitation.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: SharingInvitation - OneDrive API
+localization_priority: Normal
 ---
 # SharingInvitation resource type
 

--- a/docs/rest-api/resources/sharinglink.md
+++ b/docs/rest-api/resources/sharinglink.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: SharingLink - OneDrive API
+localization_priority: Normal
 ---
 # SharingLink resource type
 

--- a/docs/rest-api/resources/site.md
+++ b/docs/rest-api/resources/site.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Site - OneDrive API
+localization_priority: Priority
 ---
 # Working with SharePoint site resources
 

--- a/docs/rest-api/resources/sitecollection.md
+++ b/docs/rest-api/resources/sitecollection.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: SiteCollection - OneDrive API
+localization_priority: Normal
 ---
 # SiteCollection resource
 

--- a/docs/rest-api/resources/specialfolder.md
+++ b/docs/rest-api/resources/specialfolder.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: SpecialFolder - OneDrive API
+localization_priority: Normal
 ---
 # SpecialFolder resource type
 

--- a/docs/rest-api/resources/subscription.md
+++ b/docs/rest-api/resources/subscription.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Subscription - OneDrive API
+localization_priority: Normal
 ---
 # Subscription resource type
 

--- a/docs/rest-api/resources/systemfacet.md
+++ b/docs/rest-api/resources/systemfacet.md
@@ -1,8 +1,9 @@
-﻿---
+---
 author: daspek
 ms.author: dspektor
 ms.date: 09/12/2017
 title: SystemFacet - OneDrive API
+localization_priority: Normal
 ---
 # System facet
 

--- a/docs/rest-api/resources/textcolumn.md
+++ b/docs/rest-api/resources/textcolumn.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/11/2017
 title: TextColumn - OneDrive API
+localization_priority: Normal
 ---
 # TextColumn resource type
 

--- a/docs/rest-api/resources/thumbnail.md
+++ b/docs/rest-api/resources/thumbnail.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Thumbnail - OneDrive API
+localization_priority: Normal
 ---
 # Thumbnail resource type
 

--- a/docs/rest-api/resources/thumbnailSet.md
+++ b/docs/rest-api/resources/thumbnailSet.md
@@ -1,8 +1,9 @@
-﻿---
+---
 author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: ThumbnailSet - OneDrive API
+localization_priority: Normal
 ---
 # ThumbnailSet resource type
 

--- a/docs/rest-api/resources/timestamp.md
+++ b/docs/rest-api/resources/timestamp.md
@@ -1,8 +1,9 @@
-﻿---
+---
 author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Timestamp format - OneDrive API
+localization_priority: Normal
 ---
 # Timestamp type
 

--- a/docs/rest-api/resources/uploadSession.md
+++ b/docs/rest-api/resources/uploadSession.md
@@ -1,8 +1,9 @@
-﻿---
+---
 author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: UploadSession - OneDrive API
+localization_priority: Normal
 ---
 # UploadSession resource
 

--- a/docs/rest-api/resources/versionAction.md
+++ b/docs/rest-api/resources/versionAction.md
@@ -3,6 +3,7 @@ author: daspek
 ms.author: dspektor
 ms.date: 09/14/2017
 title: VersionAction - OneDrive API
+localization_priority: Normal
 ---
 # VersionAction resource type
 

--- a/docs/rest-api/resources/video.md
+++ b/docs/rest-api/resources/video.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Video - OneDrive API
+localization_priority: Normal
 ---
 # Video resource type
 

--- a/docs/rest-api/resources/webhooknotification.md
+++ b/docs/rest-api/resources/webhooknotification.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: Webhook Notification - OneDrive API
+localization_priority: Normal
 ---
 # Webhook notification resource
 

--- a/docs/sample-code.md
+++ b/docs/sample-code.md
@@ -4,6 +4,7 @@ ms.author: rgregg
 ms.date: 09/10/2017
 ms.topic: sample
 topic: Sample code for OneDrive integration
+localization_priority: Priority
 ---
 # OneDrive Files Sample Code
 

--- a/docs/terms-of-use.md
+++ b/docs/terms-of-use.md
@@ -3,6 +3,7 @@ author: rgregg
 ms.author: rgregg
 ms.date: 09/10/2017
 title: OneDrive API Terms of Use
+localization_priority: Normal
 ---
 # OneDrive API Terms and Conditions
 


### PR DESCRIPTION
Submitted by Office Intl team to apply metadata localization_priority to source markdown topics.

Contact GSXCON-Tech if you have questions.
