### PR TITLE
Add missing statement to OneDrive preview API

### DIFF
--- a/docs/rest-api/api/driveitem_preview.md
+++ b/docs/rest-api/api/driveitem_preview.md
@@ -10,6 +10,8 @@ This action allows you to obtain short-lived embeddable URLs for an item.
 
 If you wish to obtain long-lived embeddable links, use the [createLink][] API instead.
 
+> **Note:** The **preview** action is currently only available on SharePoint and OneDrive for Business.
+
 [createLink]: driveItem_createLink.md
 
 ## Permissions


### PR DESCRIPTION
Graph API docs state that preview is only supported in SharePoint and OneDrive for Business, but the OneDrive docs don't say it.  Addressing the issue in the OneDrive API doc.