### PR TITLE
Prefer descriptive parameter names in File Picker v7.2 code examples

### DIFF
--- a/docs/controls/file-pickers/js-v72/open-file.md
+++ b/docs/controls/file-pickers/js-v72/open-file.md
@@ -59,7 +59,7 @@ var odOptions = {
   advanced: {},
   success: function(files) { /* success handler */ },
   cancel: function() { /* cancel handler */ },
-  error: function(e) { /* error handler */ }
+  error: function(error) { /* error handler */ }
 }
 ```
 
@@ -166,7 +166,7 @@ var odOptions = {
   },
   success: function(files) { /* success handler */ },
   cancel: function() { /* cancel handler */ },
-  error: function(e) { /* error handler */ }
+  error: function(error) { /* error handler */ }
 }
 ```
 
@@ -187,7 +187,7 @@ var odOptions = {
   },
   success: function(files) { /* success handler */ },
   cancel: function() { /* cancel handler */ },
-  error: function(e) { /* error handler */ }
+  error: function(error) { /* error handler */ }
 }
 ```
 
@@ -206,7 +206,7 @@ var odOptions = {
   },
   success: function(files) { /* success handler */ },
   cancel: function() { /* cancel handler */ },
-  error: function(e) { /* error handler */ }
+  error: function(error) { /* error handler */ }
 }
 ```
 
@@ -236,7 +236,7 @@ var odOptions = {
   },
   success: function(files) { /* success handler */ },
   cancel: function() { /* cancel handler */ },
-  error: function(e) { /* error handler */ }
+  error: function(error) { /* error handler */ }
 }
 ```
 
@@ -252,7 +252,7 @@ var odOptions = {
   },
   success: function(files) { /* success handler */ },
   cancel: function() { /* cancel handler */ },
-  error: function(e) { /* error handler */ }
+  error: function(error) { /* error handler */ }
 ```
 
 The page you redirect to needs only to load the OneDrive SDK script:
@@ -295,7 +295,7 @@ var odOptions = {
   },
   success: function(files) { /* success handler */ },
   cancel: function() { /* cancel handler */ },
-  error: function(e) { /* error handler */ }
+  error: function(error) { /* error handler */ }
 ```
 
 

--- a/docs/controls/file-pickers/js-v72/save-file.md
+++ b/docs/controls/file-pickers/js-v72/save-file.md
@@ -59,9 +59,9 @@ var odOptions = {
   openInNewWindow: true,
   advanced: {},
   success: function(files) { /* success handler */ },
-  progress: function(p) { /* progress handler */ },
+  progress: function(percent) { /* progress handler */ },
   cancel: function() { /* cancel handler */ },
-  error: function(e) { /* error handler */ }
+  error: function(error) { /* error handler */ }
 }
 ```
 
@@ -171,7 +171,7 @@ var odOptions = {
   },
   success: function(files) { /* success handler */ },
   cancel: function() { /* cancel handler */ },
-  error: function(e) { /* error handler */ }
+  error: function(error) { /* error handler */ }
 }
 ```
 


### PR DESCRIPTION
Since I had to look-up the type of the Picker's `progress` callback, I felt like we might as well use more descriptive parameter names in our code examples.