### PR TITLE
Add license blurb to existing OneDrive File Picker release documentation pages

### DIFF
--- a/docs/controls/file-pickers/js-v5/index.md
+++ b/docs/controls/file-pickers/js-v5/index.md
@@ -271,6 +271,12 @@ The OneDrive picker and saver supports the following web browsers:
 * Latest version of Firefox
 * Latest version of Safari  
 
+## License
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the [MIT](https://opensource.org/licenses/MIT) License.
+
 <!-- {
   "type": "#page.annotation",
   "description": "Use the JavaScript picker and saver SDKs to connect your web app to OneDrive.",

--- a/docs/controls/file-pickers/js-v6/index.md
+++ b/docs/controls/file-pickers/js-v6/index.md
@@ -94,6 +94,12 @@ The OneDrive picker and saver supports the following web browsers:
 * The SDK will fail to upload a file to OneDrive for Business if the file name is taken.
 * Data URIs are not supported with OneDrive for Business.
 
+## License
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the [MIT](https://opensource.org/licenses/MIT) License.
+
 <!-- {
   "type": "#page.annotation",
   "description": "Learn how to use the JavaScript file picker SDK to connect your web app to OneDrive.",

--- a/docs/controls/file-pickers/js-v7/index.md
+++ b/docs/controls/file-pickers/js-v7/index.md
@@ -73,6 +73,11 @@ The OneDrive picker and saver supports the following web browsers:
 * [File picker SDK v6.0](../js-v6/index.md)
 * [File picker SDK v5.0](../js-v5/index.md)
 
+## License
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the [MIT](https://opensource.org/licenses/MIT) License.
 
 <!-- {
   "type": "#page.annotation",

--- a/docs/controls/file-pickers/js-v72/index.md
+++ b/docs/controls/file-pickers/js-v72/index.md
@@ -54,6 +54,12 @@ The OneDrive picker and saver supports the following web browsers:
 * Firefox Desktop & Mobile 8+
 * Safari Desktop & Mobile 5+
 
+## License
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the [MIT](https://opensource.org/licenses/MIT) License.
+
 ## Previous versions
 
 * [File picker SDK v7.0](../js-v7/index.md)


### PR DESCRIPTION
The existing releases of OneDrive File Picker have been licensed under MIT. This adds the license blurb to our documentation pages.

Future releases will be covered under MIT license also.

See https://github.com/OneDrive/onedrive-api-docs/issues/986#issuecomment-484719438.