### PR TITLE
Typo "**@odata.nextLink**"→"**\@odata.nextLink**"

### DIFF
--- a/docs/rest-api/api/driveitem_search.md
+++ b/docs/rest-api/api/driveitem_search.md
@@ -59,7 +59,7 @@ GET /me/drive/root/search(q='{search-query}')
 This method returns an object containing an collection of [DriveItems](../resources/driveitem.md) that match the search criteria.
 If no items were found, an empty collection is returned.
 
-If there are too many matches the response will be paged and an **@odata.nextLink** property will contain a URL to the next page of results.
+If there are too many matches the response will be paged and an **\@odata.nextLink** property will contain a URL to the next page of results.
 You can use the `$top` query parameter to specify the number of items in the page.
 
 <!-- { "blockType": "response", "@odata.type": "Collection(microsoft.graph.driveItem)", "truncated": true } -->


### PR DESCRIPTION
bold with escape characters

https://docs.microsoft.com/en-us/onedrive/developer/sp2019/docs/rest-api/api/driveitem_search?view=odsp-graph-online