### PR TITLE
Fix api doctor issues with driveitem_post_content.md

### DIFF
--- a/docs/rest-api/api/driveitem_post_content.md
+++ b/docs/rest-api/api/driveitem_post_content.md
@@ -45,7 +45,7 @@ The uploaded document must contain exactly two parts:
 | Name         | Type             | Description                                        |
 |:-------------|:-----------------|:---------------------------------------------------|
 | **metadata** | application/json | The metadata values to use when creating the item. |
-| **content**  | various          | The binary content of the item being created.      |
+| **content**  | binary           | The binary content of the item being created.      |
 
 The request will be rejected if more than two parts are included.
 Each part must specify a **name** value in the `Content-Disposition` header that indicates which part it is.

--- a/docs/rest-api/api/driveitem_post_content.md
+++ b/docs/rest-api/api/driveitem_post_content.md
@@ -42,7 +42,7 @@ For more information about multipart/related encoding, see [RFC 2387](https://ww
 
 The uploaded document must contain exactly two parts:
 
-| Part name    | Type             | Description                                        |
+| Name         | Type             | Description                                        |
 |:-------------|:-----------------|:---------------------------------------------------|
 | **metadata** | application/json | The metadata values to use when creating the item. |
 | **content**  | various          | The binary content of the item being created.      |


### PR DESCRIPTION
Column header names are enforced by API Doctor. Rename "Part Name" column header to just "Name".