### PR TITLE
Update special-folders-appfolder.md scopes

### DIFF
--- a/docs/rest-api/concepts/special-folders-appfolder.md
+++ b/docs/rest-api/concepts/special-folders-appfolder.md
@@ -15,8 +15,8 @@ Since it behaves like any other folder in the user's OneDrive, users can add, mo
 
 ## Getting authorization from the user
 
-To have your own app's folder, you must request either the `onedrive.appfolder` or `onedrive.readwrite` permission scope when getting an access token.
-For more details, see [authentication](../getting-started/authentication.md).
+To have your own app's folder, you must request either the `Files.ReadWrite.AppFolder` or `Files.ReadWrite` permission scope when getting an access token.
+For more details, see [authentication](../getting-started/authentication.md). Note, Business OneDrive accounts do not currently support the `Files.ReadWrite.AppFolder` permission.
 
 ## Creating your app's folder
 


### PR DESCRIPTION
special-folders-appfolder.md made reference to old onedrive.* scopes. These have been updated to the Files.* permission scopes with a note that business accounts do not support the AppFolder scope.