### PR TITLE
App registration

### DIFF
--- a/docs/controls/file-pickers/js-v72/open-file.md
+++ b/docs/controls/file-pickers/js-v72/open-file.md
@@ -11,7 +11,7 @@ The following walk through shows how to integrate the file picker SDK into your 
 
 ## 1. Register your application
 
-To use the OneDrive picker, you need to register your application through the [Microsoft Application Registration Portal](https://apps.dev.microsoft.com) and receive an Application Id.
+To use the OneDrive picker, you need to register your application through the [Azure Application Registration menu blade](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/RegisteredApps) and receive an Application Id.
 You also need to add a valid redirect URI for your web application using the picker.
 This can either be the page hosting the picker SDK or a custom URL you define. For more information see [Setting up](index.md#setting-up).
 


### PR DESCRIPTION
The app registration portal is now defunct. We need to update the documentation to use the app registrations blade in azure.