### PR TITLE
docs: fix MS App Registration Portal links

### DIFF
--- a/docs/controls/file-pickers/js-v7/index.md
+++ b/docs/controls/file-pickers/js-v7/index.md
@@ -31,9 +31,9 @@ can get shareable links for all files.
 ## Setting up
 
 To get started you need to register your application and receive an app ID
-from the [Microsoft Application Registration Portal](https://apps.dev.microsoft.com).
+from the [Azure App registrations page](https://aka.ms/AppRegistrations).
 
-1. Log in to the [Microsoft Application Registration Portal](https://apps.dev.microsoft.com)
+1. Log in to the [Azure App registrations page](https://aka.ms/AppRegistrations)
    using your Microsoft account, or a work or school account.
 2. Click **Add an app** and enter a name for your app.
 3. After your application is created, configure it to support the JavaScript picker:

--- a/docs/controls/file-pickers/js-v7/open-file.md
+++ b/docs/controls/file-pickers/js-v7/open-file.md
@@ -18,7 +18,7 @@ client-side JavaScript application.
 ## 1. Register your application
 
 To use the OneDrive picker, you need to register your application through the
-[Microsoft Application Registration Portal](https://apps.dev.microsoft.com) and
+[Azure App registrations page](https://aka.ms/AppRegistrations) and
 receive an Application Id. You also need to add a valid redirect URI for your web
 application using the picker. This can either be the page hosting the picker SDK
 or a custom URL you define. For more information see [Setting up](index.md#setting-up).

--- a/docs/controls/file-pickers/js-v7/save-file.md
+++ b/docs/controls/file-pickers/js-v7/save-file.md
@@ -18,7 +18,7 @@ start the OneDrive picker experience.
 ## 1. Register your application
 
 To use the OneDrive picker, you need to register your application through the
-[Microsoft Application Registration Portal](https://apps.dev.microsoft.com) and
+[Azure App registrations page](https://aka.ms/AppRegistrations) and
 receive an Application Id. You also need to add a valid redirect URI for your web
 application using the picker. This can either be the page hosting the picker SDK
 or a custom URL you define. For more information see [Setting up](index.md#setting-up).

--- a/docs/controls/file-pickers/js-v7/unified-js-sample.js
+++ b/docs/controls/file-pickers/js-v7/unified-js-sample.js
@@ -4,7 +4,7 @@
 var pickerOptions = {
   /*
    * Required. Provide the AppId for a registered application. Register an
-   * app on https://apps.dev.microsoft.com
+   * app on https://aka.ms/AppRegistrations
    */
   "clientId": "71a9aa4d-ae38-45e5-aeff-6c4679120247",
 
@@ -49,7 +49,7 @@ var pickerOptions = {
 var saverOptions = {
   /*
    * Required. Provide the AppId for a registered application. Register an
-   * app on https://apps.dev.microsoft.com
+   * app on https://aka.ms/AppRegistrations
    */
   "clientId": "71a9aa4d-ae38-45e5-aeff-6c4679120247",
 

--- a/docs/controls/file-pickers/js-v72/index.md
+++ b/docs/controls/file-pickers/js-v72/index.md
@@ -25,9 +25,9 @@ You can use the file picker SDK to integrate with OneDrive and SharePoint in the
 ## Setting up
 
 To get started you need to register your application and receive an app ID
-from the [Microsoft Application Registration Portal](https://apps.dev.microsoft.com).
+from the [Azure App registrations page](https://aka.ms/AppRegistrations).
 
-1. Log in to the [Microsoft Application Registration Portal](https://apps.dev.microsoft.com)
+1. Log in to the [Azure App registrations page](https://aka.ms/AppRegistrations)
    using your Microsoft account, or a work or school account.
 2. Click **Add an app** and enter a name for your app.
 3. After your application is created, configure it to support the JavaScript picker:

--- a/docs/controls/file-pickers/js-v72/open-file.md
+++ b/docs/controls/file-pickers/js-v72/open-file.md
@@ -11,7 +11,7 @@ The following walk through shows how to integrate the file picker SDK into your 
 
 ## 1. Register your application
 
-To use the OneDrive picker, you need to register your application through the [Azure Application Registration menu blade](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/RegisteredApps) and receive an Application Id.
+To use the OneDrive picker, you need to register your application through the [Azure App registrations page](https://aka.ms/AppRegistrations) and receive an Application Id.
 You also need to add a valid redirect URI for your web application using the picker.
 This can either be the page hosting the picker SDK or a custom URL you define. For more information see [Setting up](index.md#setting-up).
 

--- a/docs/controls/file-pickers/js-v72/save-file.md
+++ b/docs/controls/file-pickers/js-v72/save-file.md
@@ -11,7 +11,7 @@ To save files from OneDrive, your app should provide a button to programmaticall
 
 ## 1. Register your application
 
-To use the OneDrive picker, you need to register your application through the [Microsoft Application Registration Portal](https://apps.dev.microsoft.com) and receive an Application Id.
+To use the OneDrive picker, you need to register your application through the [Azure App registrations page](https://aka.ms/AppRegistrations) and receive an Application Id.
 You also need to add a valid redirect URI for your web application using the picker.
 This can either be the page hosting the picker SDK or a custom URL you define. For more information see [Setting up](index.md#setting-up).
 

--- a/docs/controls/file-pickers/js-v72/unified-js-sample.js
+++ b/docs/controls/file-pickers/js-v72/unified-js-sample.js
@@ -4,7 +4,7 @@
 var pickerOptions = {
     /*
     * Required. Provide the AppId for a registered application. Register an
-    * app on https://apps.dev.microsoft.com
+    * app on https://aka.ms/AppRegistrations
     */
     clientId: "71a9aa4d-ae38-45e5-aeff-6c4679120247",
 
@@ -49,7 +49,7 @@ var pickerOptions = {
 var saverOptions = {
     /*
     * Required. Provide the AppId for a registered application. Register an
-    * app on https://apps.dev.microsoft.com
+    * app on https://aka.ms/AppRegistrations
     */
     clientId: "71a9aa4d-ae38-45e5-aeff-6c4679120247",
 

--- a/docs/rest-api/concepts/special-folders-appfolder.md
+++ b/docs/rest-api/concepts/special-folders-appfolder.md
@@ -34,10 +34,10 @@ Below are the most common calls your app can make to create the folder for the f
 ### Naming your app's folder
 
 When OneDrive creates your app's folder, it uses the Application name set at that point for the calling app id.
-You may change your app's folder name in the [Microsoft Application Registration Portal][1].
-If you choose to do so, you may localize your app's folder name by going to the [Microsoft Application Registration Portal][1] and editing your app's localization settings.
+You may change your app's folder name in the [Azure App registrations page][1].
+If you choose to do so, you may localize your app's folder name by going to the [Azure App registrations page][1] and editing your app's localization settings.
 
-[1]: https://apps.dev.microsoft.com
+[1]: https://aka.ms/AppRegistrations
 
 ## Working with your app's folder
 

--- a/docs/rest-api/getting-started/app-registration.md
+++ b/docs/rest-api/getting-started/app-registration.md
@@ -10,7 +10,7 @@ localization_priority: Priority
 
 To use the OneDrive from the Microsoft Graph, you need to first register your app and receive an Application ID to represent your application in API calls.
 
-For most applications, we recommend using the Microsoft Application Registration Portal.
+For most applications, we recommend using the Azure App registrations page.
 However, for some enterprise-class applications, your app may need features that are only available via the Azure Active Directory management portal.
 If you are unsure about which approach to use, see [Deciding between Azure AD and Azure AD v2.0 endpoints](https://aka.ms/graph-auth-overview#deciding-between-the-azure-ad-and-azure-ad-v2.0-endpoints).
 
@@ -18,12 +18,12 @@ If you are unsure about which approach to use, see [Deciding between Azure AD an
 
 To connect with Microsoft Graph, you'll need a work/school account or a Microsoft account.
 
-1. Go to the [Microsoft Application Registration Portal][1].
+1. Go to the [Azure App registrations page][1].
 2. When prompted, sign in with your account credentials.
 3. Find **My applications** and click **Add an app**.
 4. Enter your app's name and click **Create application**.
 
-[1]: https://apps.dev.microsoft.com/?referrer=https%3A%2F%2Fdev.onedrive.com
+[1]: https://aka.ms/AppRegistrations/?referrer=https%3A%2F%2Fdev.onedrive.com
 
 After you've completed these steps, an application ID is created for your app and displayed on your new app's properties page.
 

--- a/docs/rest-api/getting-started/graph-oauth.md
+++ b/docs/rest-api/getting-started/graph-oauth.md
@@ -29,7 +29,7 @@ For more information see [App authentication with Microsoft Graph](https://aka.m
 ## Register your app
 
 The first step is to register an app with Microsoft and provide some details about your app.
-You can register your application and receive a new app ID from the [Microsoft Application Registration Portal](https://apps.dev.microsoft.com).
+You can register your application and receive a new app ID from the [Azure App registrations page](https://aka.ms/AppRegistrations).
 
 For detailed steps on how to register your application, see [registering your app for OneDrive API](app-registration.md).
 


### PR DESCRIPTION
Fixes #1297, fixes #1348, fixes #1354, fixes #1372
Improves #1346

- As per a blog entry (https://developer.microsoft.com/en-us/identity/blogs/deprecation-of-app-registrations-legacy-experience-and-the-application-registration-portal-apps-dev-microsoft-com/), Application Registration Portal (apps.dev.microsoft.com) has been fully deprecated since March 2020.
Instead, app registration is unified on Azure App registrations page.

- This commit will fix the existing Application Registration Portal links with Azure Portal links.

- The name 'Azure App registrations page' (come from here: https://docs.microsoft.com/en-us/azure/active-directory/develop/app-registrations-training-guide-for-app-registrations-legacy-users#differences-between-the-application-registration-portal-and-app-registrations-page) will be used instead of 'Microsoft Application Registration Portal'.