### PR TITLE
[OneDrive File Picker Schema] Folder Option only supports ODB

### DIFF
--- a/docs/controls/file-pickers/v8-schema.md
+++ b/docs/controls/file-pickers/v8-schema.md
@@ -85,7 +85,7 @@ This outlines the full schema available to configure the picker. These options a
          */
          files?: {
             /**
-             * Path segment for sub-folder within the user's OneDrive.
+             * Path segment for sub-folder within the user's OneDrive for business.
              * @example
              *  'Pictures'
              * @example


### PR DESCRIPTION
Make it explicit that `entry.oneDrive.files.folder` is only supported for OneDrive for Business