### PR TITLE
Restore rest-api/concepts section

### DIFF
--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -1,5 +1,20 @@
 # [OneDrive](index.md)
 
+# [REST APIs](rest-api/concepts/index.md)
+## [Concepts](rest-api/concepts/index.md)
+### [Addressing items](rest-api/concepts/addressing-driveitems.md)
+### [App folder](rest-api/concepts/special-folders-appfolder.md)
+### [Custom metadata](rest-api/concepts/custom-metadata-facets.md)
+### [Direct endpoint differences](rest-api/concepts/direct-endpoint-differences.md)
+### [Error responses](rest-api/concepts/errors.md)
+### [Filtering results](rest-api/concepts/filtering-results.md)
+### [Long running actions](rest-api/concepts/long-running-actions.md)
+### [Query string parameters](rest-api/concepts/optional-query-parameters.md)
+### [Scanning guidance](rest-api/concepts/scan-guidance.md)
+### [Uploading files](rest-api/concepts/upload.md)
+### [Using sharing links](rest-api/concepts/using-sharing-links.md)
+### [Working with CORS](rest-api/concepts/working-with-cors.md)
+
 # File handlers
 ## [Overview](file-handlers/index.md)
 ## [Defining actions](file-handlers/define-actions.md)

--- a/docs/breadcrumb/toc.yml
+++ b/docs/breadcrumb/toc.yml
@@ -2,6 +2,13 @@
   tocHref: /onedrive/developer
   topicHref: /onedrive/developer/index
   items:
+  - name: REST API
+    tocHref: /onedrive/developer/rest-api
+    topicHref: /onedrive/developer/rest-api/concepts/index
+    items:
+      - name: Concepts
+        tocHref: /onedrive/developer/rest-api/concepts
+        topicHref: /onedrive/developer/rest-api/concepts/index
   - name: File Handlers
     tocHref: /onedrive/developer/file-handlers
     topicHref: /onedrive/developer/file-handlers/index

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ Our developer content is designed to help you learn how and why to integrate wit
 
 The best way to connect to OneDrive, OneDrive for Business, and SharePoint document libraries is the Microsoft Graph. Microsoft Graph provides a single API endpoint for accessing a variety of Microsoft services, and makes it easy to interconnect between different services.
 
-View the [OneDrive API Reference on Microsoft Graph](https://learn.microsoft.com/en-us/graph/api/resources/onedrive) for the complete details on accessing OneDrive and SharePoint via Microsoft Graph.
+View the [OneDrive API Reference on Microsoft Graph](https://learn.microsoft.com/en-us/graph/api/resources/onedrive) for the complete details on accessing OneDrive and SharePoint via Microsoft Graph. For background on OneDrive-specific behaviors — addressing, error responses, sharing, uploads, webhooks, and more — see the [OneDrive API concepts](rest-api/concepts/index.md).
 
 To learn more about Microsoft Graph, visit the [Microsoft Graph developer portal](https://graph.microsoft.com).
 

--- a/docs/rest-api/concepts/addressing-driveitems.md
+++ b/docs/rest-api/concepts/addressing-driveitems.md
@@ -2,7 +2,224 @@
 author: JeremyKelley
 ms.author: JeremyKe
 ms.date: 09/10/2017
+ms.topic: conceptual
 title: How to address resources - OneDrive API
 ms.localizationpriority: High
-redirect_url: https://learn.microsoft.com/en-us/graph/api/resources/onedrive
 ---
+# Addressing resources in a drive on OneDrive
+
+The OneDrive API allows a single URL to address two aspects of a resource:
+
+* The **driveItem** resource
+* A property, facet, or relationship of the Item
+
+An Item facet represents an element of the resource, like the image metadata,
+folder metadata, and so on.
+
+In this example, a canonical URL for a file might look like this.
+
+```
+https://graph.microsoft.com/v1.0/me/drive/root:/Documents/MyFile.xlsx:/content
+```
+
+This example URL has these components:
+
+* `https://graph.microsoft.com/v1.0` - The version of the Microsoft Graph being used.
+* `/me` - A top-level Microsoft Graph resource being addressed, in this case the current user.
+* `/drive` - The default drive for the previous resource, in this case the user's OneDrive.
+* `/root` - The root folder for the drive.
+* `:/Documents/MyFile.xlsx:` - The `: :` around `/Documents/MyFile.xlsx` represents
+  a switch to the path-based addressing syntax. Everything between the two colons is
+  treated as a path relative to the item before the path (in this case, the root).
+* `/content` - Represents the default binary stream for the file. You can also
+  address other properties or relationships on the item.
+
+## ID-based addressing
+OneDrive supports ID-based addressing of items. Items are assigned a unique
+identifier when they are created and the ID persists across the actions a user
+performs on the item. Renaming or moving the item will not change the item's ID.
+
+ID-based addressing is a useful way to track items that might be moved by the user
+to different locations on OneDrive. As long as you have the item's ID and the item exists, you'll be
+able to find it.
+
+## Path-based addressing
+OneDrive also supports path-based addressing. This allows you to use a friendly
+URL syntax to address items relative to the hierarchy of items visible in
+OneDrive. If you know the hierarchy to an item, you can directly address that
+item, without spending any time making repeated calls to discover each level of the
+hierarchy.
+
+However, since path-based addressing is based on the name of the item, renaming
+or moving the item to a new location will cause the path of the item to change.
+
+Path-based addressing can be used relative to any item in OneDrive, which enables
+some very useful scenarios. For example, when working with shared folders, you
+can use a path-based URL relative to the shared folder's item ID to address
+something in the shared folder by path.
+
+## Examples
+These examples show the different URL formats that can be used to access data.
+All of these URLs are logically equivalent and return the content of MyFile.xlsx.
+
+| URL example                                       | Description                                              |
+|:--------------------------------------------------|:---------------------------------------------------------|
+| `/drive/root:/Documents/MyFile.xlsx:/content`     | Specified by path relative to the root of a drive.       |
+| `/drive/special/documents:/MyFile.xlsx:/content`  | Specified by filename in the `documents` special folder. |
+| `/drive/items/0123456789AB/content`               | Specified by item-id.                                    |
+| `/drives/AB0987654321/items/0123456789AB/content` | Specified by drive-id and item-id.                       |
+
+
+## Path encoding
+
+OneDrive supports addressing files and folders using the path of the item in the
+user's OneDrive. However, because the path contains user specified content which
+can potentially contain characters that are not URL safe, you should ensure proper
+encoding of any path segments.
+
+Microsoft Graph expects that URLs conform to [RFC 3986](http://tools.ietf.org/html/rfc3986).
+The following is a summary of how to properly encode paths for Microsoft Graph.
+
+### OneDrive reserved characters
+The following characters are OneDrive reserved characters, and can't be used in OneDrive folder and file names.
+
+```
+  onedrive-reserved  = "/" / "\" / "*" / "<" / ">" / "?" / ":" / "|"
+  onedrive-business-reserved
+                     = "/" / "\" / "*" / "<" / ">" / "?" / ":" / "|" / "#" / "%"
+```
+
+**Note:** Folder names can't end with a period (`.`).
+
+**Note:** OneDrive for Business file or folder names cannot begin with a tilde ('~'). 
+See [Restrictions and limitations with OneDrive for Business](https://support.microsoft.com/en-us/kb/2933738) for more information.
+
+### URI path characters
+
+When constructing the path segment of a URL for the OneDrive API, the following characters are allowed for path names, based on the URI RFC.
+
+```
+  pchar       = unreserved / pct-encoded / sub-delims / ":" / "@"
+  pct-encoded = "%" HEXDIG HEXDIG
+  unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
+  sub-delims  = "!" / "$" / "&" / "'" / "(" / ")"
+              / "*" / "+" / "," / ";" / "="
+```
+
+Item name characters, which are not included in the `pchar` group, such as `#` and ` ` (space), must be percent encoded.
+
+### Encoding characters
+Microsoft Graph uses standard percent encoding, where URL-invalid characters are encoded with a % and then the UTF-8 character code for the character. 
+For example:
+
+* `" "` -> `%20`
+* `"#"` -> `%23`
+
+### Common URL encoding mistakes
+You can't encode an entire URL in one call, because the encoding rules for each segment of a URL are different.
+Without proper encoding, the unencoded URL will be ambiguous for which segments contain which content.
+As such, you need to encode the URL path when building your URL string.
+
+For example, instead of writing this:
+
+```
+string url = url_encode("https://api.onedrive.com/v1.0/drive/root:/" + path + ":/children")
+```
+
+Write this:
+
+```
+string url = "https://api.onedrive.com/v1.0/drive/root:/" + url_path_encode(path) + ":/children")
+```
+
+However, not all URL encoding libraries respect all the requirements of standard URL path encoding.
+
+### .NET / C-Sharp / Visual Basic
+
+The .NET classes for `HttpUtility` and `Uri` include various methods for
+URL encoding. However, none of those methods properly encode all reserved
+characters for the path component of the URL (including `HttpUtility.UrlPathEncode`).
+
+Instead of using those methods, you should use `UriBuilder` to construct a
+properly escaped URL.
+
+```csharp
+UriBuilder builder = new UriBuilder("https://api.onedrive.com");
+builder.Path = "/v1.0/drive/root:/Documents/My Files/#nine.docx";
+Uri url = builder.Uri;
+```
+
+### Objective-C / iOS
+
+For Objective-C, iOS and Mac OS X development, use the `stringByAddingPercentEncodingWithAllowedCharacters` method and
+`[NSCharacterSet URLPathAllowedCharacterSet]` to properly encode the path
+component of the URL.
+
+```objc
+NSString *root = @"https://api.onedrive.com/v1.0/drive/root:/";
+NSString *path = @"Documents/My Files/#nine.docx";
+NSString *encPath = [path stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]];
+NSURL *url = [[NSURL alloc] initWithString:[root stringByAppendingString:encPath]];
+```
+
+
+### Android
+
+Use the `Uri.Builder` class to construct a properly encoded URL.
+
+```java
+Uri.Builder builder = new Uri.Builder();
+builder.
+  scheme("https").
+  authority("api.onedrive.com").
+  appendPath("v1.0").
+  appendPath("drive").
+  appendPath("root:").
+  appendPath("Documents").
+  appendPath("My Files").
+  appendPath("#nine.docx");
+String url = builder.build().toString();
+```
+
+### JavaScript
+
+Use `escape()` in JavaScript to properly encode a path component.
+
+```javascript
+var root = "https://api.onedrive.com/v1.0/drive/root:";
+var path = "/Documents/My Files/#nine.docx";
+var url = root + escape(path);
+```
+
+### Examples
+
+Here is an example of a OneDrive user (Ryan) with the following folder hierarchy:
+```
+OneDrive
+	\Ryan's Files
+		\doc (1).docx
+    \estimate%s.docx
+	\Break#Out
+		\saved_game[1].bin
+```
+
+To address each of Ryan's files, you use percent encoding, as follows:
+
+| Path                     | Encoded URL for path                      |
+|:-------------------------|:------------------------------------------|
+| `\Ryan's Files`          | `/root:/Ryan's%20Files`                   |
+| `\...\doc (1).docx`      | `/root:/Ryan's%20Files/doc%20(1).docx`    |
+| `\...\estimate%.docx`    | `/root:/Ryan's%20Files/estimate%25s.docx` |
+| `\Break#Out`             | `/root:/Break%23Out`                      |
+| `\...\saved_game[1].bin` | `/root:/Break%23Out/saved_game[1].bin`    |
+
+
+
+
+<!-- {
+  "type": "#page.annotation",
+  "description": "Learn how to address items in OneDrive by path or unique ID.",
+  "keywords": "addressing,create url, path, unique id, file id, id",
+  "section": "documentation",
+  "tocPath": "Concepts/Addressing items"
+} -->

--- a/docs/rest-api/concepts/case-sensitivity.md
+++ b/docs/rest-api/concepts/case-sensitivity.md
@@ -2,7 +2,59 @@
 author: JeremyKelley
 ms.author: JeremyKe
 ms.date: 09/10/2017
+ms.topic: conceptual
 title: Understand case sensitivity - OneDrive API
 ms.localizationpriority: Medium
-redirect_url: https://learn.microsoft.com/en-us/graph/api/resources/onedrive
 ---
+# Case sensitivity notes
+
+This topic describes the case sensitivity for parts of the OneDrive REST API in detail.
+
+## OneDrive URLs
+
+The URL scheme and authority (DNS name) are treated as case-insensitive.
+The URL path may have case-sensitive or case-insensitive components, depending on the type of resource being addressed.
+Be sure to consider everything documented here.
+
+### Resource identifiers
+
+Resource identifiers like **drive-id**, **item-id** are case-sensitive.
+
+### Path identifiers
+
+File system path identifiers used with colons (such as `:/Documents/MyFile.xlsx`) and filenames specified in the URL (such as 'MyFile.xlsx' in `/items/{item-id}/children/MyFile.xlsx`) are _not_ case-sensitive.
+
+For example, the path `:/Folder-A/Foo.txt` is treated the same as `:/folder-a/foo.TXT`. Likewise, the path `/items/{item-id}/children/Foo.txt` is treated the same as `/items/{item-id}/children/FOO.TxT`.
+
+Metadata path identifiers, such as '/items/{item-id}/image' are case-sensitive.
+
+## Query parameters
+
+The request query parameter names are case-sensitive. For example, `?select` is _not_ the same as `?SELECT`.
+
+## Request headers
+
+Per [HTTP 1.1 protocol][http-protocol], request header names are not case-sensitive. For example, `Content-Type` would be treated the same as `content-type`.
+
+The request header values are case-sensitive.
+For example, when providing an eTag or cTag value in an `if-match` header, the tag is case-sensitive.
+
+## JSON request body
+
+The keys of the JSON object supplied in the request body are case-sensitive.
+The value supplied in name-value pairs is stored as-is into the service.
+
+## JSON response body
+
+In the JSON response, the property names are camel-cased.
+The value of the property (such as item name) is returned as stored in OneDrive.
+
+[http-protocol]: http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
+
+
+<!-- {
+  "type": "#page.annotation",
+  "description": "Understand which parts of the OneDrive API are case sensitive and which are not.",
+  "keywords": "constructing urls, case sensitive",
+  "section": "documentation"
+} -->

--- a/docs/rest-api/concepts/custom-metadata-facets.md
+++ b/docs/rest-api/concepts/custom-metadata-facets.md
@@ -2,7 +2,168 @@
 author: JeremyKelley
 ms.author: dspektor
 ms.date: 09/10/2017
+ms.topic: conceptual
 title: Add custom metadata to items - OneDrive API
 ms.localizationpriority: Medium
-redirect_url: https://learn.microsoft.com/en-us/graph/api/resources/onedrive
 ---
+# Custom facets (preview)
+
+Custom facets provide a way for you to store your own metadata on items.
+This can be used to keep track of custom state alongside an item, hold a link
+to a related item in another system, and various other things. Just like
+[OneDrive's own facets](https://learn.microsoft.com/en-us/graph/api/resources/onedrive), custom facets follow a schema
+so that you can be sure the data stays consistent and valid, even when used
+with multiple apps.
+
+**Note:** Custom facets are in preview and only available for
+OneDrive Personal at this time.
+
+## Reading from custom facets
+
+To view custom facets on an item, you need to list the facet names explicitly
+in the [`select` query parameter](../concepts/optional-query-parameters.md).
+While custom facets appear alongside regular ones, they aren't returned unless
+included in the `select` statement.
+
+### Example
+
+```http
+GET /drive/items/{item-id}?select=id,name,image,contoso_oilChange
+```
+
+### Response
+
+```json
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+ "id": "beefbeef!123",
+ "name": "atom.jpg",
+ "image": {
+     "height": 1200,
+     "width": 1600
+ },
+ "contoso_oilChange": {
+     "lastOilChangeDateTime": "2014-07-06T18:05:33.79Z",
+     "lastOilChangeMileage": 6785.3,
+     "brand": "fabrikam",
+     "viscosity": "5w-30"
+ }
+}
+```
+
+## Writing to custom facets
+
+Custom facets can be provided just like regular ones on
+[create](../api/driveitem_post_children.md) or [update](../api/driveitem_update.md) calls.
+You may provide both custom facets and regular ones in the same call.
+
+### Example
+
+```http
+PATCH /drive/items/{item-id}
+Content-Type: application/json
+
+{
+   "contoso_oilChange": {
+     "lastOilChangeDateTime": "2015-08-01T20:17:12.86Z",
+     "lastOilChangeMileage": 9523.9
+   }
+ }
+```
+
+### Response
+
+```json
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "id": "12345",
+  "name": "foo",
+  "image": {
+    "height": 1080,
+    "width": 1920
+  },
+  "contoso_oilChange": {
+    "lastOilChangeDateTime": "2015-08-01T20:17:12.86Z",
+    "lastOilChangeMileage": 9523.9
+  }
+}
+```
+
+## Schema registration
+
+Before a new custom facet can be used, you need to define its schema and
+register it with OneDrive. To register your custom facet, contact
+[OneDrive Facet Registration](mailto:odwhr@microsoft.com?subject=CustomFacet%20registration&body=client_id%)
+and provide your **client_id** and schema definition JSON.
+
+Below is an example schema definition.
+
+```json
+{
+    "name": "contoso_oilChange",
+    "description": "Stores info about the last oil change for a vehicle",
+    "properties": [
+        {
+            "name": "lastOilChangeDateTime",
+            "type": "datetime",
+            "nullable": "false"
+        },
+        {
+            "name": "lastOilChangeMileage",
+            "type": "double",
+            "min": "0",
+            "max": "999999999",
+            "nullable": "false"
+        },
+        {
+            "name": "brand",
+            "type": "string",
+            "max": "24",
+            "nullable": "true"
+        },
+        {
+            "name": "viscosity",
+            "type": "string",
+            "nullable": "true"
+        }
+    ]
+}
+```
+
+## Schema definition
+
+Field                   |Description
+------------------------|-----------
+Name                    | The schema name, of the form `{appDomain}_{schemaName}`. If you own `{appDomain}.com`, you can just use {appDomain}. Otherwise, you must use your reverse DNS name, with underscores replacing the dots (ie. if your domain is 'treyresearch.net', you would use 'net_treyresearch').
+Description             | A human-readable description of the schema. For documentation purposes. Does not appear on the item.
+Properties              | The definitions of the properties in this schema. See table below.
+
+## Property definition
+
+Field      | Description
+-----------|-------------
+Name       | The name of the property, as it appears in the data. Must be lowerCamelCased and contain only the characters a-z and 0-9.
+Type       | The data type. Currently OneDrive only supports `string`, `datetime`, and `double`.
+Min        | If specified, the minimum allowed value. For strings, this is length.
+Max        | If specified, the maximum allowed value. For strings, this is length. Strings must be under 256 characters.
+Nullable   | If true, the value is optional.
+Indexed    | If true, OneDrive will allow you to query, sort, and filter based on this property's value.
+
+## Updating an existing schema definition
+You can update a schema definition, but only in ways that can't break old apps:
+
+- Existing properties can't be removed
+- All new properties must be `nullable`
+- All existing properties must have same values as before for `type`, `min`, `max`, `nullable`, and `indexed`.
+
+<!-- {
+  "type": "#page.annotation",
+  "description": "Use custom facets to store your own metadata on items.",
+  "keywords": "metadata,custom,schema,extension,extensibility,facet,facets,onedrive",
+  "section": "documentation",
+  "tocPath": "Concepts/Custom metadata"
+} -->

--- a/docs/rest-api/concepts/direct-endpoint-differences.md
+++ b/docs/rest-api/concepts/direct-endpoint-differences.md
@@ -2,7 +2,131 @@
 author: JeremyKelley
 ms.author: JeremyKe
 ms.date: 09/10/2017
+ms.topic: conceptual
 title: Understand differences between OneDrive API and Microsoft Graph
 ms.localizationpriority: High
-redirect_url: https://learn.microsoft.com/en-us/graph/api/resources/onedrive
+description: Understand the differences between Microsoft Graph and OneDrive API endpoints. Learn when to use the direct API endpoint and how to navigate namespace and property changes.
 ---
+# OneDrive API Endpoint Differences
+
+OneDrive API is available from several different API endpoints.
+Microsoft Graph is the preferred endpoint for accessing OneDrive personal, OneDrive for Business, and SharePoint online files.
+In some enterprise scenarios, like SharePoint Server 2016, it may be necessary to access OneDrive for Business and SharePoint data by using the direct API endpoint without using Microsoft Graph.
+The following notes provide details about differences you may notice between Microsoft Graph and the direct API endpoint.
+
+Differences:
+
+* [API namespaces](#namespaces)
+* [Endpoints](#discovering-an-endpoint)
+* [Permissions](#permissions)
+
+## Namespaces
+
+### Methods
+
+When using the direct endpoint, methods and actions require a namespace prefix.
+For example, to use `sharedWithMe` on the direct endpoint, you must prefix the action name with `oneDrive.`.
+Note, this prefix is case-sensitive.
+
+```http
+https://{server}/_api/v2.0/drive/oneDrive.sharedWithMe
+```
+
+The following actions or methods must be prefixed on the direct endpoint:
+
+* [Copy](../api/driveitem_copy.md)
+* [Create Sharing Link](../api/driveitem_createlink.md)
+* [Create Upload Session](../api/driveitem_createuploadsession.md)
+* [Delta](../api/driveitem_delta.md)
+* [Invite](../api/driveitem_invite.md)
+* [Recent Files](../api/drive_recent.md)
+* [Search](../api/driveitem_search.md)
+* [Shared With Me](../api/drive_sharedwithme.md)
+
+### Instance annotations
+
+Properties on items returned with an at-sign (`@`) also include a namespace.
+When using Microsoft Graph, the namespace is always `microsoft.graph`.
+However, when accessing the direct API endpoint, the namespace is different.
+
+| Documented property name (Microsoft Graph) | Direct API property name |
+| ------------------------------------------ | ------------------------ |
+| `@microsoft.graph.downloadUrl`             | `@content.downloadUrl`   |
+| `@microsoft.graph.sourceUrl`               | `@content.sourceUrl`     |
+| `@microsoft.graph.conflictBehavior`        | `@name.conflictBehavior` |
+
+### Property names
+
+Some property names on resources are changed when returned from Microsoft Graph.
+The following table contains resources and property names which are different between Microsoft Graph and OneDrive API.
+
+| Documented property name (Microsoft Graph) | Direct API property name |
+| ------------------------------------------ | ------------------------ |
+| [folder][].view                            | folder.folderView        |
+
+[folder]: ../resources/folder.md
+
+## Discovering an endpoint
+
+Microsoft Graph provides a single API endpoint, `graph.microsoft.com` for consumer and work/school accounts.
+When using the OneDrive API directly, you must discover the correct OneDrive API endpoint.
+
+To discover the correct endpoint for OneDrive API, you must use Microsoft Graph.
+
+### OneDrive personal accounts
+
+To access OneDrive API for OneDrive personal, your app must use the `https://api.onedrive.com/v1.0` endpoint for all requests.
+
+You can determine if the signed in user is a OneDrive personal user by checking the `id_token` for `tid: 9188040d-6c67-4c5b-b112-36a304b66dad`. 
+For more information, see [What is the Microsoft identity platform?](https://learn.microsoft.com/entra/identity-platform/v2-overview).
+
+### OneDrive for Business and SharePoint
+
+To access the direct API endpoint for OneDrive for Business, your app must first discover the user's My Site URL.
+You can make a request to Microsoft Graph to return this information:
+
+```http
+GET https://graph.microsoft.com/v1.0/me?$select=mySite
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "mySite": "https://contoso-my.sharepoint.com/personal/rgregg_contoso_com/"
+}
+```
+
+You can then append the API path for the OneDrive API, `_api/v2.0/` to this URL, to construct the API endpoint:
+
+```javascript
+var apiEndPoint = response.mySite + '_api/v2.0';
+```
+
+In some cases a work/school user may not have a `mySite` value returned.
+This occurs when the account has not created their OneDrive for Business yet.
+In this scenario, your app will need to use Microsoft Graph to provision the user's OneDrive by requesting the root folder of the drive from Microsoft Graph.
+
+## Permissions
+
+For calls to SharePoint and OneDrive for Business, you can assign these permission scopes to your application through the Azure Portal via the **Office 365 SharePoint Online** service.
+For OneDrive Personal, the scope string is passed into the OAuth workflow directly and do not need to be registered ahead of time.
+
+| Microsoft Graph Permission | OneDrive Personal  | SharePoint and OneDrive for Business |
+| -------------------------- | ------------------ | ------------------------------------ |
+| Files.Read                 | OneDrive.Read      | MyFiles.Read                         |
+| Files.ReadWrite            | OneDrive.ReadWrite | MyFiles.Write                        |
+| Files.ReadWrite.All        | OneDrive.ReadWrite | Files.ReadWrite.All                  |
+| Files.ReadWrite.AppFolder  | OneDrive.AppFolder | Files.ReadWrite ([Files.ReadWrite.AppFolder Not currently supported](./special-folders-appfolder.md#getting-authorization-from-the-user) |
+| Sites.Read.All             | N/A                | Sites.Read.All                       |
+| Sites.ReadWrite.All        | N/A                | Sites.ReadWrite.All                  |
+
+
+
+<!-- {
+  "type": "#page.annotation",
+  "description": "Learn the differences between using Microsoft Graph and the OneDrive API endpoint",
+  "section": "documentation",
+  "tocPath": "Misc/OneDrive endpoint"
+} -->

--- a/docs/rest-api/concepts/errors.md
+++ b/docs/rest-api/concepts/errors.md
@@ -4,5 +4,174 @@ ms.author: JeremyKe
 ms.date: 09/10/2017
 title: Error responses - OneDrive API
 ms.localizationpriority: High
-redirect_url: https://learn.microsoft.com/en-us/graph/api/resources/onedrive
 ---
+# Common error responses and codes
+
+Errors in the OneDrive API are returned using standard HTTP status codes, as well as a JSON error
+response object. The following HTTP status codes should be expected.
+
+| Status code | Status message                  | Description                                                                                                                            |
+|:------------|:--------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------|
+| 400         | Bad Request                     | Cannot process the request because it is malformed or incorrect.                                                                       |
+| 401         | Unauthorized                    | Required authentication information is either missing or not valid for the resource.                                                   |
+| 403         | Forbidden                       | Access is denied to the requested resource. The user might not have enough permission.                                                 |
+| 404         | Not Found                       | The requested resource doesn’t exist.                                                                                                  |
+| 405         | Method Not Allowed              | The HTTP method in the request is not allowed on the resource.                                                                         |
+| 406         | Not Acceptable                  | This service doesn’t support the format requested in the Accept header.                                                                |
+| 409         | Conflict                        | The current state conflicts with what the request expects. For example, the specified parent folder might not exist.                   |
+| 410         | Gone                            | The requested resource is no longer available at the server.                                               |
+| 411         | Length Required                 | A Content-Length header is required on the request.                                                                                    |
+| 412         | Precondition Failed             | A precondition provided in the request (such as an if-match header) does not match the resource's current state.                       |
+| 413         | Request Entity Too Large        | The request size exceeds the maximum limit.                                                                                            |
+| 415         | Unsupported Media Type          | The content type of the request is a format that is not supported by the service.                                                      |
+| 416         | Requested Range Not Satisfiable | The specified byte range is invalid or unavailable.                                                                                    |
+| 422         | Unprocessable Entity            | Cannot process the request because it is semantically incorrect.                                                                       |
+| 429         | Too Many Requests               | Client application has been throttled and should not attempt to repeat the request until an amount of time has elapsed.                |
+| 500         | Internal Server Error           | There was an internal server error while processing the request.                                                                       |
+| 501         | Not Implemented                 | The requested feature isn’t implemented.                                                                                               |
+| 503         | Service Unavailable             | The service is temporarily unavailable. You may repeat the request after a delay. There may be a Retry-After header.                   |
+| 507         | Insufficient Storage            | The maximum storage quota has been reached.                                                                                            |
+| 509         | Bandwidth Limit Exceeded        | Your app has been throttled for exceeding the maximum bandwidth cap. Your app can retry the request again after more time has elapsed. |
+
+The error response is a single JSON object that contains a single property
+named **error**. This object includes all of the details of the error. You may use the information returned here instead of, or in addition
+to the HTTP status code returned. Here is an example of a full JSON error body.
+
+<!-- { "blockType": "example", "@odata.type": "microsoft.graph.error", "expectError": true, "name": "example-error-response"} -->
+
+```json
+{
+  "error": {
+    "code": "invalidRange",
+    "message": "Uploaded fragment overlaps with existing data.",
+    "innererror": {
+      "code": "fragmentOverlap"
+    }
+  }
+}
+```
+
+## The code property
+
+The `code` property contains one of 15 possible values. Your apps must be
+prepared to handle any one of these errors.
+
+| Code                      | Description
+|:--------------------------|:--------------
+| **accessDenied**          | The caller doesn't have permission to perform the action. 
+| **activityLimitReached**  | The app or user has been throttled.
+| **generalException**      | An unspecified error has occurred.
+| **invalidRange**          | The specified byte range is invalid or unavailable.
+| **invalidRequest**        | The request is malformed or incorrect.
+| **itemNotFound**          | The resource could not be found.
+| **malwareDetected**       | Malware was detected in the requested resource.
+| **nameAlreadyExists**     | The specified item name already exists.
+| **notAllowed**            | The action is not allowed by the system.
+| **notSupported**          | The request is not supported by the system.
+| **resourceModified**      | The resource being updated has changed since the caller last read it, usually an eTag mismatch.
+| **resyncRequired**        | The delta token is no longer valid, and the app must reset the sync state.
+| **serviceNotAvailable**   | The service is not available. Try the request again after a delay. There may be a Retry-After header. 
+| **quotaLimitReached**     | The user has reached their quota limit.
+| **unauthenticated**       | The caller is not authenticated.
+
+The `innererror` object may recursively contain more `innererror` objects
+with additional, more specific error codes. When handling an error, apps
+should loop through all the error codes available and use the most detailed
+one that they understand. Some of the more detailed codes are listed at the
+bottom of this page.
+
+To verify that an error object is an error you are expecting, you must loop
+over the `innererror` objects, looking for the error codes you expect. For example:
+
+```csharp
+public bool IsError(string expectedErrorCode)
+{
+    OneDriveInnerError errorCode = this.Error;
+    while (null != errorCode)
+    {
+        if (errorCode.Code == expectedErrorCode)
+            return true;
+        errorCode = errorCode.InnerError;
+    }
+    return false;
+}
+```
+
+For a complete example for properly handling errors, take a look at
+[OneDrive Error Code Handling](https://gist.github.com/rgregg/a1866be15e685983b441).
+
+The `message` property at the root contains an error message intended for the
+developer to read. Error messages are not localized and shouldn't be displayed
+directly to the user. When handling errors, your code should not key off of
+`message` values because they can change at any time, and they often contain
+dynamic information specific to the failed request. You should only code
+against error codes returned in `code` properties.
+
+For more information on the resource returned in the error response, see
+the [error resource type](https://learn.microsoft.com/graph/errors) on Microsoft Graph.
+
+## Detailed error codes
+
+Below are some additional errors that your app may encounter within the nested
+`innererror` objects. Apps are not required to handle these, but may if they
+choose. The service may add new error codes or stop returning old ones at any
+time, so it is important that all apps be able to handle the basic 15 [above](#the-code-property).
+
+| Code                               | Description
+|:-----------------------------------|:----------------------------------------------------------
+| **accessRestricted**               | Access restricted to the item's owner.
+| **cannotSnapshotTree**             | Failed to get a consistent delta snapshot. Try again later.
+| **childItemCountExceeded**         | Max limit on the number of child items was reached.
+| **entityTagDoesNotMatch**          | ETag does not match the current item's value.
+| **fragmentLengthMismatch**         | Declared total size for this fragment is different from that of the upload session.
+| **fragmentOutOfOrder**             | Uploaded fragment is out of order.
+| **fragmentOverlap**                | Uploaded fragment overlaps with existing data.
+| **invalidAcceptType**              | Invalid accept type.
+| **invalidParameterFormat**         | Invalid parameter format.
+| **invalidPath**                    | Name contains invalid characters.
+| **invalidQueryOption**             | Invalid query option.
+| **invalidStartIndex**              | Invalid start index.
+| **lockMismatch**                   | Lock token does not match existing lock.
+| **lockNotFoundOrAlreadyExpired**   | There is currently no unexpired lock on the item.
+| **lockOwnerMismatch**              | Lock Owner ID does not match provided ID.
+| **malformedEntityTag**             | ETag header is malformed. ETags must be quoted strings.
+| **maxDocumentCountExceeded**       | Max limit on number of Documents is reached.
+| **maxFileSizeExceeded**            | Max file size exceeded.
+| **maxFolderCountExceeded**         | Max limit on number of Folders is reached.
+| **maxFragmentLengthExceeded**      | Max file size exceeded.
+| **maxItemCountExceeded**           | Max limit on number of Items is reached.
+| **maxQueryLengthExceeded**         | Max query length exceeded.
+| **maxStreamSizeExceeded**          | Maximum stream size exceeded.
+| **parameterIsTooLong**             | Parameter Exceeds Maximum Length.
+| **parameterIsTooSmall**            | Parameter is smaller then minimum value.
+| **pathIsTooLong**                  | Path exceeds maximum length.
+| **pathTooDeep**                    | Folder hierarchy depth limit reached.
+| **propertyNotUpdateable**          | Property not updateable.
+| **resyncApplyDifferences**         | Resync required. Replace any local items with the server's version (including deletes) if you're sure that the service was up to date with your local changes when you last sync'd. Upload any local changes that the server doesn't know about.
+| **resyncRequired**                 | Resync is required.
+| **resyncUploadDifferences**        | Resync required. Upload any local items that the service did not return, and upload any files that differ from the server's version (keeping both copies if you're not sure which one is more up-to-date).
+| **serviceNotAvailable**            | The server is unable to process the current request.
+| **serviceReadOnly**                | Resource is temporarily read-only.
+| **throttledRequest**               | Too many requests.
+| **tooManyResultsRequested**        | Too many results requested.
+| **tooManyTermsInQuery**            | Too many terms in the query.
+| **totalAffectedItemCountExceeded** | Operation is not allowed because the number of affected items exceeds threshold.
+| **truncationNotAllowed**           | Data truncation is not allowed.
+| **uploadSessionFailed**            | Upload session failed.
+| **uploadSessionIncomplete**        | Upload session incomplete.
+| **uploadSessionNotFound**          | Upload session not found.
+| **virusSuspicious**                | This document is suspicious and may have a virus.
+| **zeroOrFewerResultsRequested**    | Zero or fewer results requested.
+
+
+<!-- {
+  "type": "#page.annotation",
+  "description": "Understand the error format for the OneDrive API and error codes.",
+  "keywords": "error response, error, error codes, innererror, message, code",
+  "section": "documentation",
+  "suppressions": [
+    "Error: /docs/rest-api/concepts/errors.md/error:
+      Missing resource: resource  was not found (property name 'error')."
+  ],
+  "tocPath": "Concepts/Error responses"
+} -->

--- a/docs/rest-api/concepts/filtering-results.md
+++ b/docs/rest-api/concepts/filtering-results.md
@@ -2,7 +2,140 @@
 author: JeremyKelley
 ms.author: JeremyKe
 ms.date: 09/10/2017
+ms.topic: conceptual
 title: How to filter items - OneDrive API
 ms.localizationpriority: Medium
-redirect_url: https://learn.microsoft.com/en-us/graph/api/resources/onedrive
 ---
+# Filtering a collection
+
+The `filter` query string parameter allows clients to filter a collection of
+Items that are returned by a request. The expression specified with `filter`
+is evaluated for each resource in the collection, and only Items where the
+expression evaluates to true are included in the response. Items with
+expressions that evaluates to false or null, or Items that reference properties
+that are unavailable, are omitted from the response.
+
+OneDrive API supports only the following subset of the official [OData 4.0 filter syntax grammar][odata-filter-grammar].
+
+**Note:** Samples omit proper URL encoding for readability.
+Actual filter syntax usage must be URL encoded.
+
+_Example: return all Products whose Price is less than $10.00_
+
+```http
+GET /Products?filter=Price lt 10.00
+```
+
+The value of the `filter` option is a Boolean expression.
+
+## Supported operators
+
+OneDrive API supports the following set of operations in the `filter` syntax.
+
+| Operator | Description           | Example                                                 |
+|:---------|:----------------------|:--------------------------------------------------------|
+| `eq`     | Equal                 | `city eq 'Redmond'`                                     |
+| `ne`     | Not equal             | `city ne 'London'`                                      |
+| `gt`     | Greater than          | `price gt 20`                                           |
+| `ge`     | Greater than or equal | `price ge 10`                                           |
+| `lt`     | Less than             | `price lt 20`                                           |
+| `le`     | Less than or equal    | `price le 10`                                           |
+| `and`    | Logical and           | `price le 200 and price gt 3.5`                         |
+| `or`     | Logical or            | `price le 3.5 or price gt 200`                          |
+| `( )`    | Precedence grouping   | `(priority eq 1 or city eq 'Redmond') and price gt 100` |
+
+## Operator precedence
+
+Operators for the `filter` syntax are evaluated in the following order, from
+highest to lowest. Operators in the same group/category have equal precedence
+and are evaluated from left-to-right.
+
+| Group           | Operator | Description           |
+|:----------------|:---------|:----------------------|
+| Grouping        | `( )`    | Precedence grouping   |
+| Relational      | `gt`     | Greater than          |
+|                 | `ge`     | Greater than or equal |
+|                 | `lt`     | Less than             |
+|                 | `le`     | Less than or equal    |
+| Equality        | `eq`     | Equal                 |
+|                 | `ne`     | Not equal             |
+| Conditional AND | `and`    | Logical and           |
+| Conditional OR  | `or`     | Logical or            |
+
+## Filterable properties
+
+While the **filter** syntax can be used on any property of an item, we have
+optimized certain properties to be fast and efficient to filter on.
+
+**Note:** In OneDrive for Business, SharePoint Online and SharePoint Server 2016, filtering support only **name** and **url** properties.
+
+* audio
+* createdDateTime (for gt, ge, lt, le)
+* deleted
+* file
+* folder
+* image
+* lastModifiedDateTime (for gt, ge, lt, le)
+* video
+
+Filtering on other properties which are not optimized can result in the following
+behaviors:
+
+* Higher API latency (longer return time for response)
+* Empty pages (no items in the value collection but an **odata.nextLink**
+  property for the next page)
+
+### Example
+
+Below is an example of filtering search results for only items that have a
+**file** and **image** facet.
+
+#### Request
+
+```
+GET /drive/root/search(q='vacation')?filter=image%20ne%20null%20and%20file%20ne%20null
+```
+
+#### Response
+
+```http
+HTTP/1.1 200 OK
+Content-type: application/json
+
+{
+    "value": [
+      {
+        "id": "0123456789abc!123",
+        "name": "Vacation.jpg",
+        "image": { },
+        "file": { },
+        "searchResult":
+        {
+          "onClickTelemetryUrl": "https://bing.com/0123456789abc!123"
+        }
+      },
+      {
+        "id": "0123456789abc!456",
+        "name": "Summer.jpg",
+        "image": { },
+        "file": { },
+        "searchResult":
+        {
+          "onClickTelemetryUrl": "https://bing.com/0123456789abc!456"
+        }
+      }
+    ],
+    "@search.approximateCount": 12,
+    "@odata.nextLink": "https://api.onedrive.com/drive/root/search?query=vacation&skipToken=1asdlnjnkj1nalkm!asd"
+}
+```
+
+[odata-filter-grammar]: http://docs.oasis-open.org/odata/odata/v4.0/errata02/os/complete/part1-protocol/odata-v4.0-errata02-os-part1-protocol-complete.html#_Toc406398301
+
+<!-- {
+  "type": "#page.annotation",
+  "description": "Filter the results of a collection based on values for properties of items returned.",
+  "keywords": "search,filter,restrict,limit,query,items,files",
+  "section": "documentation",
+  "tocPath": "Items/Filter"
+} -->

--- a/docs/rest-api/concepts/http-verb-tunneling.md
+++ b/docs/rest-api/concepts/http-verb-tunneling.md
@@ -2,7 +2,43 @@
 author: JeremyKelley
 ms.author: JeremyKe
 ms.date: 09/10/2017
+ms.topic: conceptual
 title: Tunneling HTTP verbs - OneDrive API
 ms.localizationpriority: Medium
-redirect_url: https://learn.microsoft.com/en-us/graph/api/resources/onedrive
 ---
+# Using additional HTTP verbs when your client is limited
+
+There are some cases where apps can't make HTTP requests with verbs other than
+GET or POST. For example, some proxies, firewalls, etc. might be configured by
+their operators to block certain HTTP verbs, or certain app environments might
+not support other verbs. For these cases, the OneDrive API provides an
+alternative way of specifying an HTTP verb when necessary.
+
+You can tunnel any HTTP request through a POST by making a POST request and
+adding the `X-HTTP-Method-Override` header set to the method you want to invoke.
+This signals the server to process the request not as a POST, but as whatever
+verb was specified as the value of that header.
+
+This header is only valid for POST requests. It will be ignored for other HTTP
+methods.
+
+For example, if the DELETE verb is blocked by a firewall, your application can
+tunnel the verb to the API to ensure that your app can still delete a file.
+
+
+```http
+POST /drive/items/{item-id} HTTP/1.1
+Host: api.onedrive.com
+X-HTTP-Method-Override: DELETE
+```
+
+This request will delete the resource identified. The response from the service
+will match the response that would have been returned if the HTTP method had
+DELETE.
+
+<!-- {
+  "type": "#page.annotation",
+  "description": "Verb tunneling enables a client that doesn't support all HTTP verbs to work.",
+  "keywords": "verb,tunneling,tunnelling,post",
+  "section": "documentation"
+} -->

--- a/docs/rest-api/concepts/index.md
+++ b/docs/rest-api/concepts/index.md
@@ -4,5 +4,33 @@ ms.author: JeremyKe
 ms.date: 09/10/2017
 title: OneDrive API concepts overview
 ms.localizationpriority: High
-redirect_url: https://learn.microsoft.com/en-us/graph/api/resources/onedrive
 ---
+# OneDrive integration concepts
+
+While working with data in OneDrive via the Microsoft Graph, the following concepts are beneficial to understand.
+
+* [Addressing items in a drive](addressing-driveitems.md)
+* [API permissions](permissions_reference.md)
+* [Best practices for discovering files and detecting changes at scale](scan-guidance.md)
+* [Calling the API from JavaScript and CORS](working-with-cors.md)
+* [Case sensitivity](case-sensitivity.md)
+* [Common error responses](errors.md)
+* [Customizing API responses with OData query parameters](optional-query-parameters.md)
+* [Filtering results](filtering-results.md)
+* [OneDrive API direct endpoint differences](direct-endpoint-differences.md)
+* [Receiving webhook notifications](using-webhooks.md)
+* [Sharing items in OneDrive](sharing.md)
+* [Storing user content in an application folder](special-folders-appfolder.md)
+* [Tunneling HTTP verbs](http-verb-tunneling.md)
+* [Uploading files to OneDrive](upload.md)
+* [Using custom metadata](custom-metadata-facets.md)
+* [Working with long-running actions](long-running-actions.md)
+* [Working with sharing links](using-sharing-links.md)
+
+
+<!-- {
+  "type": "#page.annotation",
+  "description": "Learn about the concepts necessary to work with OneDrive items",
+  "section": "documentation",
+  "tocPath": "REST APIs/Concepts"
+} -->

--- a/docs/rest-api/concepts/long-running-actions.md
+++ b/docs/rest-api/concepts/long-running-actions.md
@@ -2,7 +2,116 @@
 author: JeremyKelley
 ms.author: JeremyKe
 ms.date: 09/10/2017
+ms.topic: conceptual
 title: Calling long running actions - OneDrive API
 ms.localizationpriority: Medium
-redirect_url: https://learn.microsoft.com/en-us/graph/api/resources/onedrive
+description: Learn how to handle long-running actions with Microsoft OneDrive's API. Understand how to request action status reports and monitor progress effectively.
 ---
+# Working with APIs that make take a long time to complete
+
+Some scenarios, like [copy](../api/driveitem_copy.md) or [upload from URL](../api/driveitem_upload_url.md) cannot always be completed in a finite amount of time.
+To handle these scenarios and keep API response latency low, these actions are implemented using a long running actions pattern.
+
+1. App requests a long running action via the API. The API accepts the action and returns a `202 Accepted` response along with a Location header for the API URL to retrieve action status reports.
+2. App requests the action status report URL and receives an [AsyncJobStatus](../resources/asyncJobStatus.md) response with the progress of the long running action
+3. The long running action completes. Next time the app requests the action status report URL and receives an [AsyncJobStatus](../resources/asyncJobStatus.md) response with the completion of the action.
+
+## Initial action request
+
+Let's walk through the steps for an example [copy](../api/driveitem_copy.md) scenario.
+In this scenario, an app requests to copy a folder with a large amount of data contained within.
+This request will likely take several seconds to complete since the amount of data is large.
+
+<!-- { "blockType": "request", "name": "lro-copy-item-example", "scopes": "files.readwrite", "tags": "service.graph" } -->
+
+```http
+POST /drive/items/{folder-item-id}/copy
+Content-Type: application/json
+Prefer: respond-async
+
+{
+  "parentReference": {
+    "path": "/drive/root:/Documents"
+  },
+  "name": "Copy of LargeFolder1"
+}
+```
+
+The API responds that the action was accepted and the URL for retrieving the status of the long running action.
+
+<!-- { "blockType": "response" } -->
+
+```http
+HTTP/1.1 202 Accepted
+Location: https://api.onedrive.com/monitor/4A3407B5-88FC-4504-8B21-0AABD3412717
+```
+
+In many cases this many be the end of the request, since the copy action will complete without the app doing any additional work.
+However, if the app wants to show the status of the copy action or ensure that it completes without error, it can do so using the monitor URL.
+
+## Retrieve a status report from the monitor URL
+
+To check on the status of the copy action, the app makes a request to the URL provided in the previous response.
+*Note:* This request does not require authentication, since the URL is short-lived and unique to the original caller. 
+
+<!-- { "blockType": "ignored", "name": "lro-check-status", "scopes": "files.readwrite" } -->
+```http
+GET https://api.onedrive.com/monitor/4A3407B5-88FC-4504-8B21-0AABD3412717
+```
+
+The service responses with information that the long running action is still in progress:
+
+<!-- { "blockType": "ignored", "@odata.type": "microsoft.graph.asyncJobStatus" } -->
+```http
+HTTP/1.1 202 Accepted
+Content-type: application/json
+
+{
+  "operation": "ItemCopy",
+  "percentageComplete": 27.8,
+  "status": "inProgress"
+}
+```
+
+This information can be used to provide an update to the user about the progress of the copy action.
+The app can continue to poll the monitor URL to request status updates and keep track of the progress of the action.
+
+## Retrieve a completed status report from the monitor URL
+
+After a few seconds the copy operation has completed.
+This time when the app makes a request to the monitor URL the response is a redirection to the finished result of the action.
+
+<!-- { "blockType": "ignored", "name": "lro-check-status-complete", "scopes": "files.readwrite" } -->
+
+```http
+GET https://api.onedrive.com/monitor/4A3407B5-88FC-4504-8B21-0AABD3412717
+```
+
+When the action has completed, the response from the monitor service will return the resourceId for the results.
+
+<!-- { "blockType": "response", "@odata.type": "microsoft.graph.asyncJobStatus" } -->
+
+```http
+HTTP/1.1 303 See Other
+Content-type: application/json
+
+{
+    "percentageComplete": 100.0,
+    "resourceId": "01MOWKYVJML57KN2ANMBA3JZJS2MBGC7KM",
+    "status": "completed"
+}
+```
+
+
+## Retrieve the results of the completed operation
+
+
+
+
+<!-- {
+  "type": "#page.annotation",
+  "description": "Monitor the progress of long-running actions in the API.",
+  "keywords": "monitor,long,running,operation,action",
+  "section": "documentation",
+  "tocPath": "Concepts/Long running actions"
+} -->

--- a/docs/rest-api/concepts/migrating-from-live-sdk.md
+++ b/docs/rest-api/concepts/migrating-from-live-sdk.md
@@ -1,8 +1,0 @@
----
-author: JeremyKelley
-ms.author: JeremyKe
-ms.date: 10/16/2017
-title: Migrating from Live SDK to Microsoft Graph
-ms.localizationpriority: Medium
-redirect_url: https://learn.microsoft.com/en-us/graph/api/resources/onedrive
----

--- a/docs/rest-api/concepts/optional-query-parameters.md
+++ b/docs/rest-api/concepts/optional-query-parameters.md
@@ -2,7 +2,152 @@
 author: JeremyKelley
 ms.author: JeremyKe
 ms.date: 09/10/2017
+ms.topic: conceptual
 title: Modifying responses with query parameters - OneDrive API
 ms.localizationpriority: High
-redirect_url: https://learn.microsoft.com/en-us/graph/api/resources/onedrive
 ---
+# Using query parameters to change the shape of a response
+
+The OneDrive API provides several optional query parameters that can be used to control the specific data returned in a response.
+
+Covered in this topic:
+
+* [Selecting properties](#selecting-properties)
+* [Expanding collections](#expanding-collections)
+* [Sorting collections](#sorting-collections)
+
+## Selecting properties
+You can use the _select_ query string parameter to provide a comma-separated
+list of properties to return on [Items][item-resource].
+
+### Example
+
+This example selects only the **name** and **size** properties to be returned, when retrieving the children of an item.
+
+```http
+GET /drive/root/children?select=name,size
+```
+
+By submitting the request with the `select=name,size` query string, the objects
+in the response will only have those property values included. When using the
+select statement, you need to specify all properties to return in the statement.
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "value": [
+    {
+      "id": "13140a9sd9aba",
+      "name": "Documents",
+      "size": 1024
+    },
+    {
+      "id": "123901909124a",
+      "name": "Pictures",
+      "size": 1012010210
+    }
+  ]
+}
+```
+
+## Expanding collections
+
+In OneDrive API requests, children collections of referenced items are not automatically
+expanded. This is by design because it reduces network traffic and the time it takes to generate a response
+from the service. However, in some cases you might want to include those results
+in a response.
+
+You can use the _expand_ query string parameter to instruct the OneDrive API to expand
+a children collection and include those results.
+
+For example, to retrieve the root drive information and the top level items in
+a drive you use the _expand_ parameter as in the example below. This example also uses a _select_
+statement to only return the **id** and **name** properties of the children items.
+
+```http
+GET /drive/root?expand=children(select=id,name)
+```
+
+The request returns the collection items, with the children collection expanded.
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "id": "12312312541",
+  "name": "root",
+  "size": 218753122201,
+  "webUrl": "https://onedrive.live.com/?cid=0f040...",
+  "folder": {
+    "childCount": 4
+  },
+  "children": [
+    {
+      "id": "F04AA961744A809!48443",
+      "name": "Applications",
+    },
+    {
+      "id": "F04AA961744A809!92647",
+      "name": "Attachments",
+    },
+    {
+      "id": "F04AA961744A809!93269",
+      "name": "Balsmiq Sketches",
+    },
+    {
+      "id": "F04AA961744A809!65191",
+      "name": "Camera imports",
+    }
+  ]
+}
+```
+
+## Sorting collections
+
+You can use the _orderby_ query string to control the sort order of the items
+returned from the OneDrive API. For a collection of items, use the following fields in the _orderby_ parameter.
+
+* name
+* size
+* lastModifiedDateTime
+
+Note that in OneDrive for Business and SharePoint Server 2016, the _orderby_ query string only works with **name** and **url**.
+
+To sort the results in ascending or descending order, append
+either `asc` or `desc` to the field name, separated by a space, for example,
+`?orderby=name%20desc`.
+
+For example, to return the contents of the root of a drive in OneDrive, ordered largest
+to smallest, use this syntax: `/drive/items/root/children?orderby=size%20desc`.
+
+
+## Optional OData query parameters
+Here is a table of optional OData query parameters you can use in your OneDrive API requests.
+
+| Name        | Value  | Status        | Description                                                                                                                                                          |
+|:------------|:-------|:--------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| _expand_    | string | available     | Comma-separated list of relationships to expand and include in the response. For example, to retrieve the children of a folder use `expand=children`.                |
+| _select_    | string | available     | Comma-separated list of properties to include in the response.                                                                                                       |
+| _skipToken_ | string | available     | Paging token that is used to get the next set of results.                                                                                                            |
+| _top_       | int    | available     | The number of items to return in a result set. The OneDrive API may have a hard limit that prevents you from asking for more items per response.                     |
+| _orderby_   | string | available     | Comma-separated list of properties that are used to sort the order of items in the response collection. Works for `name`, `size`, and `lastModifiedDateTime` fields. |
+| _filter_    | string | not available | Filter string that lets you filter the response based on a set of criteria.                                                                                          |
+
+
+
+**Note:** The OData standard prefixes these terms with a `$`. 
+OneDrive API supports using these query parameters either with or without the special character, but you must be consistent throughout the request with your usage of the `$` character on these arguments.
+
+ [item-resource]: ../resources/driveitem.md
+
+
+ <!-- {
+   "type": "#page.annotation",
+   "description": "Details about optional query string parameters you can use to shape results.",
+   "keywords": "constructing urls, query string, query value, query parameter",
+   "section": "documentation",
+   "tocPath": "Concepts/Query string parameters"
+ } -->

--- a/docs/rest-api/concepts/permissions_reference.md
+++ b/docs/rest-api/concepts/permissions_reference.md
@@ -4,5 +4,89 @@ ms.author: JeremyKe
 ms.date: 09/10/2017
 title: Understanding OneDrive API permission scopes
 ms.localizationpriority: High
-redirect_url: https://learn.microsoft.com/en-us/graph/api/resources/onedrive
 ---
+# Permissions for OneDrive API
+
+OneDrive and SharePoint expose a few granular permissions that control the access that apps have to resources.
+When a user signs in to your app they, or, in some cases, an administrator, are required to consent to these permissions.
+If consent is given, your app is given access to the resources and APIs that it has requested.
+For apps that don't take a signed-in user, permissions can be pre-consented to by an administrator when the app is installed or during sign-up. 
+
+For more details about the full set of Microsoft Graph permissions, please see [Permissions reference for Microsoft Graph](https://learn.microsoft.com/graph/permissions-reference).
+
+## Files permissions
+
+#### Delegated permissions
+
+| Permission                  | Display String                                         | Description                                                                                                                                                                                             | Admin Consent Required |
+| :-------------------------- | :----------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :--------------------- |
+| _Files.Read_                | Read user files                                        | Allows the app to read the signed-in user's files.                                                                                                                                                      | No                     |
+| _Files.Read.All_            | Read all files that user can access                    | Allows the app to read all files the signed-in user can access.                                                                                                                                         | No                     |
+| _Files.ReadWrite_           | Have full access to user files                         | Allows the app to read, create, update, and delete the signed-in user's files.                                                                                                                          | No                     |
+| _Files.ReadWrite.All_       | Have full access to all files user can access          | Allows the app to read, create, update, and delete all files the signed-in user can access.                                                                                                             | No                     |
+| _Files.ReadWrite.AppFolder_ | Have full access to the application's folder (preview) | (Preview) Allows the app to read, create, update, and delete files in the application's folder.                                                                                                         | No                     |
+| _Files.Read.Selected_       | Read files that the user selects                       | **Limited support in Microsoft Graph - see Remarks** <br/> (Preview) Allows the app to read files that the user selects. The app has access for several hours after the user selects a file.            | No                     |
+| _Files.ReadWrite.Selected_  | Read and write files that the user selects             | **Limited support in Microsoft Graph -- see Remarks** <br/> (Preview) Allows the app to read and write files that the user selects. The app has access for several hours after the user selects a file. | No                     |
+
+#### Application permissions
+
+| Permission            | Display String                               | Description                                                                                                    | Admin Consent Required |
+| :-------------------- | :------------------------------------------- | :------------------------------------------------------------------------------------------------------------- | :--------------------- |
+| _Files.Read.All_      | Read files in all site collections           | Allows the app to read all files in all site collections without a signed in user.                             | Yes                    |
+| _Files.ReadWrite.All_ | Read and write files in all site collections | Allows the app to read, create, update, and delete all files in all site collections without a signed in user. | Yes                    |
+
+### Remarks
+
+The Files.Read, Files.ReadWrite, Files.Read.All, and Files.ReadWrite.All delegated permissions are valid on both personal Microsoft accounts and work or school accounts.
+Note that for personal accounts, Files.Read and Files.ReadWrite also grant access to files shared with the signed-in user. 
+
+The Files.Read.Selected and Files.ReadWrite.Selected delegated permissions are only valid on work or school accounts and are only exposed for working with [Office 365 file handlers (v1.0)](https://msdn.microsoft.com/office/office365/howto/using-cross-suite-apps).
+They should not be used for directly calling Microsoft Graph APIs. 
+
+The Files.ReadWrite.AppFolder delegated permission is only valid for personal accounts and is used for accessing the [App Root special folder](special-folders-appfolder.md) with the OneDrive [Get special folder](../api/drive_get_specialfolder.md) Microsoft Graph API.
+
+
+### Example usage
+#### Delegated
+
+* _Files.Read_ : Read files stored in the signed-in user's OneDrive (`GET /me/drive/root/children`)
+* _Files.Read.All_ : Read files shared with the signed-in user (`GET /me/drive/root/sharedWithMe`)
+* _Files.ReadWrite_ : Write a file in the signed-in user's OneDrive (`PUT /me/drive/root/children/filename.txt/content`)
+* _Files.ReadWrite.All_ : Write a file shared with the user (`PUT /users/rgregg@contoso.com/drive/root/children/file.txt/content`)
+* _Files.ReadWrite.AppFolder_ : Write files into the app's folder in OneDrive (`PUT /me/drive/special/approot/children/file.txt/content`)
+
+--- 
+
+## Sites permissions
+
+#### Delegated permissions
+
+| Permission              | Display String                                                   | Description                                                                                                                   | Admin Consent Required |
+| :---------------------- | :--------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------- | :--------------------- |
+| _Sites.Read.All_        | Read items in all site collections                               | Allows the app to read documents and list items in all site collections on behalf of the signed-in user.                      | No                     |
+| _Sites.ReadWrite.All_   | Read and write items in all site collections                     | Allows the app to edit or delete documents and list items in all site collections on behalf of the signed-in user.            | No                     |
+| _Sites.Manage.All_      | Create, edit, and delete items and lists in all site collections | Allows the app to manage and create lists, documents, and list items in all site collections on behalf of the signed-in user. | No                     |
+| _Sites.FullControl.All_ | Have full control of all site collections                        | Allows the app to have full control to SharePoint sites in all site collections on behalf of the signed-in user.              | Yes                    |
+
+#### Application permissions
+
+| Permission              | Display String                                                   | Description                                                                                                                   | Admin Consent Required |
+| :---------------------- | :--------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------- | :--------------------- |
+| _Sites.Read.All_        | Read items in all site collections                               | Allows the app to read documents and list items in all site collections without a signed in user.                             | Yes                    |
+| _Sites.ReadWrite.All_   | Read and write items in all site collections                     | Allows the app to create, read, update, and delete documents and list items in all site collections without a signed in user. | Yes                    |
+| _Sites.Manage.All_      | Have full control of all site collections                        | Allows the app to manage and create lists, documents, and list items in all site collections without a signed-in user.        | Yes                    |
+| _Sites.FullControl.All_ | Create, edit, and delete items and lists in all site collections | Allows the app to have full control to SharePoint sites in all site collections without a signed-in user.                     | Yes                    |
+
+
+### Remarks
+
+Sites permissions are valid only on work or school accounts.
+
+### Example usage
+
+#### Delegated
+
+* _Sites.Read.All_ : Read the lists on the SharePoint root site (`GET /v1.0/sites/root/lists`)
+* _Sites.ReadWrite.All_ : Create new list items in a SharePoint list (`POST /v1.0/sites/root/lists/123/items`)
+* _Sites.Manage.All_ : Add a new list to a SharePoint site (`POST /v1.0/sites/root/lists`)
+* _Sites.FullControl.All_ : Complete access to SharePoint sites and lists.

--- a/docs/rest-api/concepts/scan-guidance.md
+++ b/docs/rest-api/concepts/scan-guidance.md
@@ -2,7 +2,136 @@
 author: killerewok2000
 ms.author: Sibourda
 ms.date: 10/02/2025
+ms.topic: conceptual
 title: Best practices for discovering files and detecting changes at scale
 ms.localizationpriority: High
-redirect_url: https://learn.microsoft.com/en-us/graph/api/resources/onedrive
 ---
+# Best practices for discovering files and detecting changes at scale
+SharePoint and OneDrive store trillions of files.  It is critical to use the right calling patterns when trying to understand all files and changes at scale. Historically, there are many APIs to access files at an atomic level.  Many of these APIs are not efficient at a large scale but work well for a single user interaction. This guidance walks through how to monitor an Office 365 tenant or OneDrive so that your application integrates with Office 365 with maximum performance and efficiency. Applications that typically have this type of need are sync engines, backup providers, search indexers, classification engines, and data loss prevention providers. 
+
+## Getting the right permissions
+To build trust with users it is important to use the correct minimal set of [permission scopes][] needed for an app to function.  Most scanning applications will want to operate with Application permissions, this indicates your application is running independently of any particular user.  To access files you should request either the **Files.Read.All** or **Files.ReadWrite.All** scope.  For access to SharePoint resources, including the list of all site collections, **Sites.Read.All** or **Sites.ReadWrite.All** is appropriate.  In order to process permissions correctly you will also need to request **Sites.FullControl.All**.
+
+### Authorization types, permission scopes and users
+When you configure an application's permissions in Microsoft Azure you can choose between Application permissions and Delegated permissions.  As noted above, most scanning applications will want [Application permissions][].  Delegated permissions require your application to operate in the context of a signed in user rather than globally.  In the delegated model you are restricted to content that the current user has access to.
+
+One important aspect of permissions to note is that when an administrator grants permissions to an application requesting Application permissions (rather than Delegated permissions), the permission grant is being associated with the tenant and application, rather than the administrator user.  Although an administrator is required to grant the access, the access grant does not confer any special administrative permissions to the application, beyond access to the resource scopes requested by the application.
+
+## Recommended calling pattern
+For applications that process large amounts of data from SharePoint and OneDrive, you should follow a consistent calling pattern like the following.
+1.	**Discover** – Configure the locations that you want to scan. 
+2.	**Crawl** – Discover and process the entire set of files that you are interested in.
+3.	**Notify** – Monitor changes to those files via notification.
+4.	**Process changes** – Reprocess only files that have changed by using delta query.
+
+The pattern will look like the following diagram.  This article goes into detail on each step for implementation.
+
+![Scanning calling flow between Microsoft Graph and client application](../../media/ScanProcessFlow.png)
+
+Each of these elements may have several mechanisms to accomplish them in the Microsoft Graph API and existing SharePoint APIs.  The goal of this article is to give you the best way available today to complete each task.
+
+Throttling and / or performance slowdowns have a higher tendency to occur during peak hours than off-peak hours for large amounts of calls and / or bandwidth utilization. This is to help protect the service and ensure reliability for end users. Off peak hours are typically nights and weekends in your region’s time zone. Where your SharePoint tenant is set up determines your region’s time zone.
+
+## Discover locations to scan
+
+Configuring the locations that you want your application to scan is a manual process today.  In many cases, you will want to provide a user-facing application experience for this step; how you expose this capability and whether it is exposed to all users or just administrators is up to you.  You will want to determine which users’ OneDrives and which SharePoint site collections and subsites you are scanning.
+
+Each user’s OneDrive contains a single [drive][] that you can monitor.  SharePoint site collections and subsites may have multiple drives, one for each document library in the site.  You can discover each drive in a site by using the /drives endpoint.  For example, to get all drives in the root site of the tenant you can use:
+
+```
+https://graph.microsoft.com/v1.0/sites/root/drives
+```
+
+The drive is the starting point for large-scale file activities.  You’ll use these drives to get complete lists of files, connect webhooks for notifications, and use delta query to get sets of changes to items in the drives.
+
+### How to find SharePoint site collections and OneDrive for Business drives
+
+Using Microsoft Graph with Application permissions, you can obtain the full list of site collections, including sites containing OneDrive for Business drives.  To get this list use the following API call:
+
+```
+GET /sites
+```
+
+The sites enumeration API also supports the [delta query][] to get information about new sites created or changes to site structure.  Delta query support for site enumeration is currently rolling out to the Microsoft Graph Beta version.  Please keep reading for more information about delta query.
+
+To receive notifications about new site collections you can subscribe to web hooks using the Microsoft Graph [subscriptions][] endpoint.  The target resource for these notifications is **/sites**.  You will receive notifications when new site collections are created or deleted as well as when sub sites or lists are created.
+
+## Crawl and process by using delta query
+
+To get the initial list of files in a drive, make a single [delta query][] call with no parameters.  The delta query gives apps an initial crawl of all content and then subsequent changes from a point in time.  The delta query returns the link necessary to get future changes each time it is called.
+
+For example, if you wanted to get all the files in the default document library in a SharePoint site, you could use this query:
+
+```
+/sites/{siteId}/drive/root/delta
+```
+
+This API returns pages of results that represent all the files in the drive.  After you’ve retrieved all the pages of files by using the returned @odata.nextLink, you can make the delta query again with the returned @odata.deltaLink to get changes since the last time you called delta query.  Always remember to keep the URL returned by @odata.deltaLink so you can efficiently check for the changes later on.
+
+The links returned by the delta query will look like this:
+
+```
+{
+    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)",
+    "@odata.deltaLink": "https://graph.microsoft.com/v1.0/me/drive/root/delta?$select=*%2csharepointIds&token=MzslMjM0OyUyMzE7MzsyM2YwNDVhMS1lNmRmLTQ1N2MtOGQ5NS1hNmViZDVmZWRhNWQ7NjM2NzExNzY2MzIxMDcwMDAwOzE5ODAzMzU5ODslMjM7JTIzOyUyMzQ",
+    "value": [
+        {
+            "@odata.type": "#microsoft.graph.driveItem",
+            "createdDateTime": "2017-07-27T02:41:36Z",
+…
+}
+```
+
+For a more detailed sample, see the delta query [documentation][].
+
+Delta query returns an array of [driveItems][].  If you know ahead of time that you want specific information, you can include it on a select statement with the delta query.  You can additionally follow up the delta call with a request for a specific driveItem should you need it.  Delta query will still help narrow down the number of items you have to query against for changes, making your application more efficient.
+
+## Get notified of changes by using webhooks
+
+To make best use of the delta query for changes happening on a drive, you need an effective strategy to know when to come back and ask for the changes.  In the past, you may have written your app to poll OneDrive and SharePoint at some fixed interval and enumerated the changes yourself.  With delta query, the enumeration part is done for you, so you just need to know when to come back.  Webhooks allow you to avoid polling the service, and instead receive a notification when something has changed that you’re interested in.  Polling the service repeatedly or at high rates causes your app to be throttled due to excessive calling patterns.
+
+Webhooks are attached by using the subscriptions API for Microsoft Graph.  You can find the full documentation for Microsoft Graph webhooks and the Subscriptions API [on the Microsoft Graph site][].
+
+You will need to create a subscription that is associated with a specific resource (in this case a drive).  Drives support the “update” change type for webhooks.  An “update” indicates that content within the drive has changed or that new content has been added or deleted.  Webhook subscriptions have an associated timeout that needs to be periodically refreshed.  See the earlier-mentioned documentation on how to refresh your subscriptions.  We recommend using delta query with your last change token immediately after you subscribe to webhooks to ensure that you don’t miss any changes that happened between initial crawl and setting up your webhooks.
+
+Even with webhooks sending your application notifications, you may want to provide a periodic delta query to ensure that no changes are missed if it appears to have been a long time since a notification was received.  We recommend no more than once per day for this periodic check.  The delta query still allows you to easily catch up and not miss any changes in the system.
+
+### Receiving webhook notifications for security events
+OneDrive and SharePoint support sending your application notifications of security events.  To subscribe to these events you will need to add the "prefer:includesecuritywebhooks" header to your request to register a webhook.  Once the webhook is registered you will receive notifications when the permissions on an item change.  This header is applicable to SharePoint and OneDrive for Business but not consumer OneDrive accounts.
+
+## Process changes
+
+After your application receives a notification through a webhook, you need to acknowledge the notification by immediately sending a 202 – Accepted code back to Microsoft Graph.  You should send this code before beginning any time-consuming processing.  Failing to do so results in additional retries being sent, which your app might view as false notifications.
+
+Follow up the acknowledgement with a delta query for the latest changes, and your app should be up to date.  If you are expecting heavy traffic patterns on a particular drive, you should consider calling delta query at a reduced interval rather than after each change notification.  Also, make sure to store the new value returned in the deltaLink parameter to get a new token for calling the API again.
+
+If your processing requires downloading the contents of an individual file, you can use the cTag property to determine if the contents of the file have changed since the last time you downloaded it.  Once you know you want to download the file, you can access the [/content][] property of the DriveItem returned in a delta query response.
+
+### Scanning permissions hierarchies
+
+By default, the delta query response will include sharing information for items even if they inherit their permissions from their parent and did not have direct sharing changes themselves.  Note that the delta query response only includes items with direct changes to their content or metadata and the parent hierarchy of the changed items.  This typically then results in a follow up call to get the permission details for every item rather than just the ones whose sharing information changed.  You can optimize your understanding of how permission changes happen by adding the "Prefer: hierarchicalsharing" header to your delta query request.
+
+When the "Prefer: hierarchicalsharing" header is provided, sharing information will be returned for the root of the permissions hierarchy, as well as items that explicitly have sharing changes.  In cases where the sharing change is to remove sharing from an item you will find an empty sharing facet to differentiate between items that inherit from their parent and those that are unique but have no sharing links.  You will also see this empty sharing facet on the root of a permission hierarchy that is not shared to establish the initial scope.
+
+In many scanning scenarios you may be interested specifically in changes to permissions.  To make it clear in the delta query response which changes are the result of permissions being changed you can provide the "Prefer: deltashowsharingchanges" header.  When this header is provided all items that appear in the delta query response due to permission changes will have the "@microsoft.graph.sharedChanged":"True" OData annotation present when calling against Microsoft Graph, when using the SharePoint or OneDrive API directly the annotation will be "@oneDrive.sharedChanged":"True".  Like the security webhooks, this feature is applicable to SharePoint and OneDrive for Business but not consumer OneDrive accounts.  
+
+## What happens when you get throttled? 
+
+In some scenarios, your application may get a 429 or 503 response from Microsoft Graph.  This indicates that your request is currently being throttled.  One thing to keep in mind is that SharePoint throttles applications based on an application's use with each customer tenant.  Serving a request for one resource in a tenant will correspondingly give you less resources to make a call to another resource for that same tenant.  Ultimately there could be multiple reasons why your app receives a throttle response and it is critical that your app responds correctly in these situations.
+
+To recover from receiving a 429 or 503 response code, try again after waiting for the duration specified in the Retry-After field in the response header.  If throttling persists, the Retry-After value may become longer over time, allowing the system to recover.  Apps that do not honor the retry after duration before calling back will be blocked due to abusive calling patterns. 
+
+When waiting for 429 or 503 recovery you should ensure that you pause all further requests you are making to the service. This is especially important in multi-threaded scenarios.  Making additional calls while receiving throttle responses will extend the time it takes for your app to become unthrottled. 
+
+For more detailed information about how Microsoft Graph resources work with throttling, see the [Microsoft Graph throttling guidance][].
+
+[permission scopes]: https://aka.ms/permissionscopesdoc
+[Application permissions]: https://aka.ms/applicationpermissiondoc
+[drive]: https://aka.ms/drivedoc
+[delta query]: https://aka.ms/deltadoc
+[documentation]: https://aka.ms/deltadoc
+[driveItems]: https://aka.ms/driveitemdoc
+[on the Microsoft Graph site]: https://aka.ms/webhookdoc
+[Microsoft Graph throttling guidance]: https://aka.ms/throttlingdoc
+[/content]: https://aka.ms/driveitemcontentdoc
+[subscriptions]: https://aka.ms/webhookdoc

--- a/docs/rest-api/concepts/sharing.md
+++ b/docs/rest-api/concepts/sharing.md
@@ -2,7 +2,40 @@
 author: JeremyKelley
 ms.author: JeremyKe
 ms.date: 09/10/2017
+ms.topic: conceptual
 title: Sharing items - OneDrive API
 ms.localizationpriority: Medium
-redirect_url: https://learn.microsoft.com/en-us/graph/api/resources/onedrive
+description: Learn how to share items in OneDrive and SharePoint using sharing links or item permissions. Discover how to create, read, update, and remove permissions.
 ---
+# Sharing items in OneDrive and SharePoint
+
+OneDrive Personal, OneDrive for Business, and SharePoint provide two different
+primary ways to share items with other users:
+
+* **Sharing links** make it easy to share files with anyone who has the link. The link
+  includes the authentication required to access the file and allows either read
+  or read-write access to the shared item.
+* **Permissions** on the item allow it to be shared with specific users who must be
+  signed in to access the files.
+
+OneDrive API supports creating both sharing links and item permissions.
+
+## Tasks for sharing items
+
+| Task                                           | HTTP method                                      |
+|:-----------------------------------------------|:-------------------------------------------------|
+| [Create a sharing link](../api/driveitem_createlink.md) | `POST /drive/items/{item-id}/createLink`         |
+| [Add permissions](../api/driveitem_invite.md)                   | `POST /drive/items/{item-id}/invite`             |
+| [Read permissions](../api/driveitem_list_permissions.md)             | `GET /drive/items/{item-id}/permissions`         |
+| [Remove permissions](../api/permission_delete.md)     | `DELETE /drive/items/{item-id}/permissions/{id}` |
+| [Update permissions](../api/permission_update.md)     | `PATCH /drive/items/{item-id}/permissions/{id}`  |
+| [Send sharing invitation](../api/driveitem_invite.md)           | `POST /drive/items/{item-id}/invite`             |
+
+<!-- {
+  "type": "#page.annotation",
+  "description": "Overview of various ways to share items with OneDrive API",
+  "keywords": "sharing items files folders onedrive sharepoint",
+  "section": "documentation",
+  "tocPath": "Sharing"
+
+} -->

--- a/docs/rest-api/concepts/special-folders-appfolder.md
+++ b/docs/rest-api/concepts/special-folders-appfolder.md
@@ -2,7 +2,72 @@
 author: JeremyKelley
 ms.author: JeremyKe
 ms.date: 09/10/2017
+ms.topic: conceptual
+description: "Use the app root special folder to create a home for your app's user content."
 title: What is an App Folder - OneDrive API
 ms.localizationpriority: High
-redirect_url: https://learn.microsoft.com/en-us/graph/api/resources/onedrive
 ---
+# Using an App Folder to store user content without access to all files
+
+The _App Folder_ is a dedicated, special folder for your app.
+The App Folder is typically named after your app, and is found in the **Apps** folder in the user's OneDrive.
+If you request the `Files.ReadWrite.AppFolder` permission scope and the user authorizes it, your app gets read and write access to this folder.
+Since it behaves like any other folder in the user's OneDrive, users can add, modify, and remove content from it. Your app doesn't need to maintain logic unique to the user, which allows the user to rename or move it.
+
+## Getting authorization from the user
+
+To have your own app's folder, you must request either the `Files.ReadWrite.AppFolder` or `Files.ReadWrite` permission scope when getting an access token.
+For more details, see [authentication and authorization basics for Microsoft Graph](https://learn.microsoft.com/graph/auth/auth-concepts).
+
+## Creating your app's folder
+
+OneDrive creates your app's folder in the user's `Apps` folder, located in the root of the user's OneDrive, when your app makes the first call to the folder using the [special folder](../api/drive_get_specialfolder.md) namespace.
+Below are the most common calls your app can make to create the folder for the first time.
+
+* [Get your app folder's metadata](../api/driveitem_get.md): `GET /drive/special/approot`
+* [List your app folder's children](../api/driveitem_list_children.md): `GET /drive/special/approot/children`
+* [Create a folder under the approot](../api/driveitem_post_children.md): `POST /drive/special/approot/children`
+* [Create an upload session](../api/driveitem_createuploadsession.md): `POST /drive/special/approot:/{filename}:/createUploadSession`
+* [Upload an item's content](../api/driveitem_put_content.md): `PUT /drive/special/approot:/{fileName}:/content`
+* [Upload an item's content w/ metadata](../api/driveitem_post_content.md): `POST /drive/special/approot/children`
+* [Upload an item's content from URL](../api/driveitem_upload_url.md): `POST /drive/special/approot/children`
+
+### Naming your app's folder
+
+When OneDrive creates your app's folder, it uses the Application name set at that point for the calling app id.
+You may change your app's folder name in the [Azure App registrations page][1].
+If you choose to do so, you may localize your app's folder name by going to the [Azure App registrations page][1] and editing your app's localization settings.
+Changing your app's folder name in the [Azure App registrations page][1] will not rename existing special folders associated with your app.
+
+[1]: https://aka.ms/AppRegistrations
+
+## Working with your app's folder
+
+Your app's folder supports all the standard `item` operations.
+
+| Common task                                         | HTTP method (by path)                                       |
+| --------------------------------------------------- | ----------------------------------------------------------- |
+| [Get metadata for an Item](../api/driveitem_get.md)         | `GET /drive/special/approot:/{path}`                        |
+| [List an Item's children](../api/driveitem_list_children.md)         | `GET /drive/special/approot:/{path}:/children`              |
+| [Create an Item](../api/driveitem_post_children.md)                | `PUT /drive/special/approot:/{parent-path}/{name}`          |
+| [Upload an Item's contents](../api/driveitem_put_content.md)     | `PUT /drive/special/approot:/{parent-path}/{name}:/content` |
+| [Update an Item's contents](../api/driveitem_update.md)     | `PATCH /drive/special/approot:/{path}`                      |
+| [Delete an Item](../api/driveitem_delete.md)                | `DELETE /drive/special/approot:/{path}`                     |
+| [Move an Item](../api/driveitem_move.md)                    | `PATCH /drive/special/approot:/{path}`                      |
+| [Copy an Item](../api/driveitem_copy.md)                    | `POST /drive/special/approot:/{path}:/action.copy`          |
+| [Download an Item's contents](../api/driveitem_get_content.md) | `GET /drive/special/approot:/{path}:/content`               |
+| [Download specific file format](../api/driveitem_get_content_format.md)   | `GET /drive/special/approot:/{path}:/content?format={format}` |
+| [Search for an Item](../api/driveitem_search.md)            | `GET /drive/special/approot:/{path}:/search`                |
+| [View changes on an Item][item-changes]             | `GET /drive/special/approot:/{path}:/delta`                 |
+| [Get thumbnails for an Item][get-thumbnails]        | `GET /drive/special/approot:/{path}:/thumbnails`            |
+
+[item-changes]: ../api/driveitem_delta.md
+[get-thumbnails]: ../api/driveitem_list_thumbnails.md
+
+<!-- {
+  "type": "#page.annotation",
+  "description": "Use the app root special folder to create a home for your app's user content.",
+  "keywords": "approot, app folder, application folder, special folder, home folder",
+  "section": "documentation",
+  "tocPath": "Concepts/App folder"
+} -->

--- a/docs/rest-api/concepts/upload.md
+++ b/docs/rest-api/concepts/upload.md
@@ -2,7 +2,37 @@
 author: JeremyKelley
 ms.author: JeremyKe
 ms.date: 09/10/2017
+ms.topic: conceptual
 title: Uploading files - OneDrive API
 ms.localizationpriority: High
-redirect_url: https://learn.microsoft.com/en-us/graph/api/resources/onedrive
 ---
+# Upload contents for an item on OneDrive
+
+Items on OneDrive with a [File facet][file-facet] have one or more streams of content
+associated with the item. The default stream represents the contents of the
+file. Other streams may be used to represent item thumbnails or alternative
+data formats.
+
+There are four OneDrive APIs that can be used to upload the contents of an item. The
+correct method to use depends on where the content is coming from and how large
+the contents of the item are.
+
+* **[Simple item upload](../api/driveitem_put_content.md)** is available for items with less than 4 MB of content.
+
+* **[Resumable item upload](../api/driveitem_createuploadsession.md)** is provided for large files or when a resumable transfer may be necessary.
+
+* **[Multipart item upload](../api/driveitem_post_content.md)** allows you to upload both the contents of an item and provide metadata about the item in the same call.
+    This is only available for OneDrive Personal.
+
+* **[Upload from URL (preview)](../api/driveitem_upload_url.md)** allows you to upload the contents of a file by providing a URL where the contents of the file can be retrieved.
+    This is only available for OneDrive Personal.
+
+[file-facet]: ../resources/file.md
+
+<!-- {
+  "type": "#page.annotation",
+  "description": "Methods for how files can be uploaded to OneDrive.",
+  "keywords": "upload,upload methods,simple,resumable,multipart,from url",
+  "section": "documentation",
+  "tocPath": "Items/Upload"
+} -->

--- a/docs/rest-api/concepts/using-sharing-links.md
+++ b/docs/rest-api/concepts/using-sharing-links.md
@@ -2,7 +2,165 @@
 author: JeremyKelley
 ms.author: JeremyKe
 ms.date: 09/10/2017
+ms.topic: conceptual
 title: Accessing shared files and folders - OneDrive API
 ms.localizationpriority: High
-redirect_url: https://learn.microsoft.com/en-us/graph/api/resources/onedrive
 ---
+# Using remote items to access shared files and folders
+
+OneDrive supports adding a shared folder to a drive in order to make accessing
+content from a shared folder easier. When a shared folder is added to
+OneDrive, the folder appears in the root, and its contents are synchronized using the OneDrive sync client.
+
+When enumerating a collection of items, shared folders appear as items
+with the **[remoteItem](../resources/remoteitem.md)** facet. This facet
+includes the information necessary to access the contents of the shared folder
+using the OneDrive API.
+
+## Add a shared folder to the user's drive
+
+Before a shared folder can be added to the user's drive, the following
+requirements must be met:
+
+* The user has explicit permission to the shared folder, and isn't accessing the shared folder through a link.
+* Your app needs read/write access to the drive where the shared folder will be
+  added.
+
+**Note:** A shared folder can only be added to the root of a user's drive.
+
+To add the shared folder to a drive, your app POSTs to the drive's root collection
+with the details of the shared folder in the **remoteItem** facet. For example:
+
+```http
+POST /drive/root/children
+Content-Type: application/json
+
+{
+  "name": "Team Documents",
+  "remoteItem": {
+      "id": "12345abcde!1221",
+      "parentReference": { "driveId": "12345abcde" }
+  }
+}
+```
+
+**Note:** **driveId** and **id** are required.
+
+If successful, the service responds with the complete details of the
+created remote item:
+
+```http
+HTTP/1.1 201 Created
+Content-Type: application/json
+
+{
+  "id": "98765432!12399",
+  "name": "Team Documents",
+  "remoteItem": {
+    "id": "12345abcde!1221",
+    "parentReference": {
+      "driveId": "12345abcde"
+    },
+    "folder": { "childCount": 15 }
+  },
+  "lastModifiedDateTime": "2015-08-10T13:47:11Z",
+  "createdDateTime": "2015-08-10T13:47:11Z",
+}
+```
+
+## Remove a shared folder from the user's drive
+
+To remove a shared folder, simply DELETE the remote item:
+
+```http
+DELETE /drive/items/{local-item-id}
+```
+
+This will return a **204 No Content** if the shared folder was removed
+successfully. This does not delete the shared folder or items contained in the
+shared folder.
+
+```http
+HTTP/1.1 204 No Content
+```
+
+## Enumerate the contents of a shared folder
+
+A remote item provides the information necessary to make a call to the actual
+item it represents. The remote item is a placeholder in the user's
+drive for that item, but cannot be accessed like an item in the user's drive.
+For example, requesting the **children** collection for a remote item will
+result in an error from the server.
+
+In this example, consider the following remote item:
+
+<!-- { "blockType": "example", "@odata.type": "microsoft.graph.driveItem", "name": "mount-point", "truncated": true } -->
+```json
+{
+  "id": "98765432!12399",
+  "name": "Team Documents",
+  "remoteItem": {
+    "id": "12345abcde!1221",
+    "parentReference": {
+      "driveId": "12345abcde"
+    }
+  },
+  "lastModifiedDateTime": "2015-08-10T13:47:11Z",
+  "createdDateTime": "2015-08-10T13:47:11Z"
+}
+```
+
+To enumerate the contents of this shared folder, the **remoteItem** property is
+used to construct a request to the shared folder contained in the remote
+drive.
+
+```http
+GET /drives/{drive-id}/items/{item-id}/children
+```
+
+This example returns the children of the shared folder, by calling into the
+parent drive of the shared folder.
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "value":
+  [
+    {
+      "id": "12345abcde!9912",
+      "name": "Team Roster.xlsx",
+      "file": {  },
+      "size": 90122
+    }
+  ]
+}
+```
+
+## Using Delta with remote items
+
+When using **[delta](../api/driveitem_delta.md)** in a drive with
+shared folders, the shared folder themselves will be returned as part of the
+response but the items contained within a shared folder will not be returned. A
+separate call to **delta** and separate cached delta token is required for each shared folder.
+
+## Moving items into a shared folder
+
+The OneDrive API does not support moving or copying items into
+a shared folder. New items can be created in the folder by using the regular
+[upload actions](../concepts/upload.md) and targeting the remoteItem
+**driveId** and **id**.
+
+
+<!-- {
+  "type": "#page.annotation",
+  "description": "Learn how to access shared folders and remote items in OneDrive API.",
+  "keywords": "shared folders, mountpoint, mount points, remote items, symlink, onedrive, shared, items, linked",
+  "section": "documentation",
+  "suppressions": [
+    "Error: /docs/rest-api/concepts/using-sharing-links.md/remoteItem:
+      Missing resource: resource  was not found (property name 'remoteItem')."
+  ],
+  "tocPath": "Concepts/Remote items"
+} -->

--- a/docs/rest-api/concepts/using-webhooks.md
+++ b/docs/rest-api/concepts/using-webhooks.md
@@ -2,7 +2,143 @@
 author: JeremyKelley
 ms.author: JeremyKe
 ms.date: 09/10/2017
+ms.topic: conceptual
 title: Webhook notifications - OneDrive API
 ms.localizationpriority: High
-redirect_url: https://learn.microsoft.com/en-us/graph/api/resources/onedrive
 ---
+# Using webhooks to receive service-to-service notifications
+
+OneDrive provides service-to-service notifications through [webhooks][wiki-webhooks].
+Webhooks provide a simple notification pipeline so your app can
+be aware of changes to a user's drive without polling the service.
+
+When items your app has access to in a user's drive are changed, the URL you
+provide will be sent a request notifying it that changes have occurred.
+
+[wiki-webhooks]: http://en.wikipedia.org/wiki/Webhook
+
+## Common tasks
+
+| Task                                                | HTTP method                        |
+|-----------------------------------------------------|------------------------------------|
+| [Create a new subscription](../api/subscription_post_subscriptions.md) | `POST /subscriptions`              |
+| [Delete subscription](../api/subscription_delete.md)       | `DELETE /subscriptions/{id}`       |
+| [Update a subscription](../api/subscription_update.md)     | `PATCH /subscriptions/{id}`        |
+
+## Registering
+
+To register for webhooks, you add a new subscription to the item representing
+the top of the scope for which you wish to receive changes.
+
+See [adding a new subscription](../api/subscription_post_subscriptions.md) for details on how to
+register a URL for notifications.
+
+### Scope of notifications
+
+Webhook notifications will be sent to your app only for changes that meet
+the following criteria:
+
+* A user has authorized your app to have access to OneDrive content.
+* The app has access to the item that generates the notification.
+* The subscription has not expired.
+
+Your app will not receive notifications for items that have been shared with
+the user who has signed in or remote items in the user's drive unless separate
+subscriptions are created on the original items.
+
+## Receiving notifications
+
+Once your subscription is created, OneDrive will send POST requests
+to your registered URL when items under the notification scope are changed.
+Multiple notifications to your service may be batched together into a single
+request, if multiple users have changes that occur within the same time period.
+
+#### Example notification
+
+The body of the HTTP request to your notification URL will contain a [Webhook Notification](../resources/webhooknotification.md)
+resource similar to the following:
+
+<!-- { "blockType": "example", "@odata.type": "microsoft.graph.webhookNotification",
+"truncated": true, "isCollection": true } -->
+```json
+{
+  "value": [
+    {
+      "subscriptionId": "A640DFF3-0429-44FC-AF7E-30523A476864",
+      "expirationDateTime": "2017-02-22T16:00:00Z",
+      "resource": "/me/drive/root",
+      "clientState": "client-specific string"
+    }
+  ]
+}
+```
+
+You'll notice that the notification doesn't include any information about the
+changes that triggered it. Your app is expected
+to use the **delta** verb to detect any changes to the state of items in
+OneDrive and store the `syncToken` value for the next time you are notified.
+
+
+#### Error handling
+
+If an error occurs while sending the notification to your service, OneDrive
+will follow exponential back-off logic. Any response with an HTTP
+status code outside of the 200-299 range, or that times out, will be attempted
+again over the next several minutes. If the request is not successful after 15
+minutes, the notification is dropped.
+
+Future notifications will still be attempted to your service, although the
+service reserves the right to remove the subscription if a sufficient number of
+failures are detected.
+
+#### Expiration
+
+New subscriptions are automatically provided an expiration date if one is not
+provided when the subscription is created. By default, subscriptions are set
+to expire 6 months from when they are created.
+
+### Best practices
+
+When you use webhooks there are some important things to consider:
+
+##### Service-to-service
+
+You should not attempt to use webhooks to notify client devices directly. Each
+app has a single webhook URL that is called for all users. This URL
+should point to a service you control. You can choose to have your service
+parse the notification messages and forward appropriate push notifications to
+client apps as you want.
+
+##### Respond quickly
+
+Your app has limited time to respond to the request. You should queue
+information about notification updates, and then
+process those requests on a separate thread. You should not attempt to pull
+changes from the OneDrive service before responding to the webhook request.
+
+##### Expect concurrent notifications
+
+In many circumstances you might receive notifications for the same user multiple
+times in quick succession. For example, if a user is new or is uploading a batch
+of content to OneDrive, you can receive multiple notifications for the same user
+before you have processed the first notification. Ensure that the actions that
+respond to webhook notifications properly handle this case.
+
+<!-- {
+  "type": "#page.annotation",
+  "description": "Use webhooks to receive notifications when your app users change items.",
+  "keywords": "notification,push,sync,webhook,onedrive",
+  "section": "documentation",
+  "suppressions": [
+    "Warning: /docs/rest-api/concepts/using-webhooks.md/container/clientState:
+      Undocumented property 'clientState' [String] was not expected on resource microsoft.graph.webhookNotification.",
+    "Warning: /docs/rest-api/concepts/using-webhooks.md/container/expirationDateTime:
+      Undocumented property 'expirationDateTime' [DateTimeOffset] was not expected on resource microsoft.graph.webhookNotification.",
+    "Warning: /docs/rest-api/concepts/using-webhooks.md/container/resource:
+      Undocumented property 'resource' [String] was not expected on resource microsoft.graph.webhookNotification.",
+    "Warning: /docs/rest-api/concepts/using-webhooks.md/container/subscriptionId:
+      Undocumented property 'subscriptionId' [Guid] was not expected on resource microsoft.graph.webhookNotification."
+  ],
+  "tocPath": "Concepts/Notifications",
+  "tocBookmarks": { "Webhooks": "#" }
+} -->

--- a/docs/rest-api/concepts/webhook-receiver-validation-request.md
+++ b/docs/rest-api/concepts/webhook-receiver-validation-request.md
@@ -2,7 +2,48 @@
 author: JeremyKelley
 ms.author: JeremyKe
 ms.date: 09/10/2017
+ms.topic: conceptual
 title: Validating webhook subscriptions - OneDrive API
 ms.localizationpriority: Medium
-redirect_url: https://learn.microsoft.com/en-us/graph/api/resources/onedrive
 ---
+# Handling webhook validation requests
+
+When a new subscription is created, OneDrive will validate the webhook URL
+supports receiving webhook notifications. This validation is performed
+during the [create subscription](../api/subscription_post_subscriptions.md) request. The subscription
+will only be created if your service responds correct.
+
+When a new subscription is created, OneDrive will POST a request to the
+registered URL in the following format:
+
+## Example validation request
+
+```http
+POST https://contoso.azurewebsites.net/your/webhook/service?validationToken={randomString}
+Content-Length: 0
+```
+
+## Response
+
+For the subscription to be created successfully, your service must respond
+to this request by returning the value of the **validationToken** query string
+parameter as a plain-text response.
+
+```http
+HTTP/1.1 200 OK
+Content-Type: text/plain
+
+{randomString}
+```
+
+If your application returns a status code other than `200` or fails to respond
+with the value of the validationtoken parameter, the request to create a new
+subscription will fail.
+
+<!-- {
+  "type": "#page.annotation",
+  "description": "Learn how to respond to a webhook validation request.",
+  "keywords": "notification,list,subscription,webhook,create,validate,validation",
+  "section": "documentation",
+  "tocPath": "Webhooks/Validation"
+} -->

--- a/docs/rest-api/concepts/working-with-cors.md
+++ b/docs/rest-api/concepts/working-with-cors.md
@@ -2,7 +2,101 @@
 author: JeremyKelley
 ms.author: JeremyKe
 ms.date: 09/10/2017
+ms.topic: conceptual
 title: CORS support - OneDrive API
-ms.localizationpriority: Normal
-redirect_url: https://learn.microsoft.com/en-us/graph/api/resources/onedrive
+
+localization_priority: Normal
+description: Master OneDrive API with CORS for seamless JavaScript integration. Explore sample code, requests, and file downloads. Boost your app's performance.
+
 ---
+# Using the OneDrive API in JavaScript apps (CORS support)
+
+The OneDrive API supports [HTTP access control (CORS)](http://www.w3.org/TR/cors/) to allow single page JavaScript applications to use the OneDrive API through the common [XMLHttpRequest pattern][xhr-scenario].
+
+You can read more about CORS (Cross-Origin Resource Sharing) on [Wikipedia](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) or the [W3C CORS Wiki](http://www.w3.org/wiki/CORS).
+
+[xhr-scenario]: https://msdn.microsoft.com/en-us/library/hh772834(v=vs.85).aspx
+
+## Sample code
+
+The OneDrive Explorer JS sample app demonstrates how to use the OneDrive API from a JavaScript app. 
+This sample shows you how to browse and navigate the contents of a user's OneDrive in JavaScript.
+
+You can try the [OneDrive explorer sample app](https://dev.onedrive.com/odx) or [view the source code](https://github.com/onedrive/onedrive-explorer-js).
+
+## Example request
+
+This example creates a CORS request that returns the items from a user's OneDrive, by sending a GET request to the `/drive/root/children` endpoint.
+The example was generated using [test-cors.org](http://test-cors.org).
+
+```js
+var createCORSRequest = function(method, url) {
+  var xhr = new XMLHttpRequest();
+  if ("withCredentials" in xhr) {
+    // Most browsers.
+    xhr.open(method, url, true);
+  } else if (typeof XDomainRequest != "undefined") {
+    // IE8 & IE9
+    xhr = new XDomainRequest();
+    xhr.open(method, url);
+  } else {
+    // CORS not supported.
+    xhr = null;
+  }
+  return xhr;
+};
+
+var url = 'https://graph.microsoft.com/v1.0/me/drive/root/children';
+var method = 'GET';
+var xhr = createCORSRequest(method, url);
+
+xhr.onload = function() {
+  // Success code goes here.
+};
+
+xhr.onerror = function() {
+  // Error code goes here.
+};
+
+xhr.setRequestHeader('Authorization', 'Bearer access_token_value');
+xhr.send();
+```
+
+## Downloading OneDrive files in JavaScript apps
+
+To download files from OneDrive in a JavaScript app you cannot use the `/content` API, since this responds with a `302` redirect. 
+A `302` redirect is explicitly prohibited when a CORS _preflight_ is required, such as when providing the **Authorization** header.
+
+Instead, your app needs to select the `@microsoft.graph.downloadUrl` property, which returns the same URL that `/content` would have redirected to.
+This URL can then be requested directly using XMLHttpRequest.
+Because these URLs are pre-authenticated they can be retrieved without a CORS preflight request.
+
+### Example
+
+To retrieve the download URL for a file, first make a request that includes the `@microsoft.graph.downloadUrl` property:
+
+```http
+GET /drive/items/{item-id}?select=id,@microsoft.graph.downloadUrl
+```
+
+This returns the id and download URL for a file:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "id": "12319191!11919",
+  "@microsoft.graph.downloadUrl": "https://..."
+}
+```
+
+You can then make an XMLHttpRequest for the URL provided in `@microsoft.graph.downloadUrl` to retrieve the file.
+
+<!-- {
+  "type": "#page.annotation",
+  "description": "Learn more about using the OneDrive API from a single page JavaScript app",
+  "keywords": "cors, http access control, javascript, single, page, application, app",
+  "section": "documentation",
+  "tocPath": "Concepts/Working with CORS"
+} -->


### PR DESCRIPTION
PR #1919 redirected all rest-api docs to Microsoft Graph. Feedback after that change indicated the Concepts material was uniquely valuable as in-repo prose and should come back, while the api/, resources/, and getting-started/ subtrees remain redirected.

Restores the 20 files under docs/rest-api/concepts/ to their pre-removal content and wires Concepts back into TOC.md, breadcrumb/toc.yml, and a mention from docs/index.md.

Polish on top of the restore:
- Top-level REST APIs nav now points at concepts/index.md (not the redirect stub rest-api/index.md), same for the breadcrumb topicHref.
- Deleted migrating-from-live-sdk.md: spoke about a Nov 2018 deadline in future tense.
- Replaced dead/stale links: ../getting-started/authentication.md and ../resources/error.md / index.md#facets now point at the corresponding Microsoft Graph pages; permissions-reference URL updated from the retired developer.microsoft.com/graph/docs/ path; deprecated OAuth implicit-flow doc replaced with Microsoft identity platform overview.
- Fixed typo "resposnes" -> "responses" in concepts/index.md and synced it with the promoted TOC entries.
- Renamed TOC entries for clarity: "Filter" -> "Filtering results", "OneDrive endpoint" -> "Direct endpoint differences".
- Added ApiDoctor suppressions on errors.md and using-sharing-links.md for the residual microsoft.graph.error and remoteItem resource-missing errors that PR #1919 stripped definitions for.
- Removed blockType:"request"/paired-response annotations from 5 example HTTP calls whose CSDL serialization fails (drive/driveItem types are no longer defined locally). The HTTP code samples render identically; only ApiDoctor's now-impossible schema validation is dropped.

Local build: Test-Docs.ps1 -> 100% passed, exit 0.